### PR TITLE
Allow for email notifications with GitLab

### DIFF
--- a/config.js
+++ b/config.js
@@ -84,6 +84,12 @@ const schema = {
     default: null,
     env: 'GITHUB_TOKEN'
   },
+  githubWebhookSecret: {
+    doc: 'Token to verify that webhook requests are from GitHub',
+    format: String,
+    default: null,
+    env: 'GITHUB_WEBHOOK_SECRET'
+  },
   gitlabAccessTokenUri: {
     doc: 'URI for the GitLab authentication provider.',
     format: String,
@@ -101,6 +107,12 @@ const schema = {
     format: String,
     default: null,
     env: 'GITLAB_TOKEN'
+  },
+  gitlabWebhookSecret: {
+    doc: 'Token to verify that webhook requests are from GitLab',
+    format: String,
+    default: null,
+    env: 'GITLAB_WEBHOOK_SECRET'
   },
   port: {
     doc: 'The port to bind the application to.',

--- a/controllers/handlePR.js
+++ b/controllers/handlePR.js
@@ -108,7 +108,7 @@ module.exports = async (repo, data) => {
      * Only necessary for GitHub, as GitLab automatically deletes the backing branch for the
      * pull/merge request. For GitHub, this will throw the following error if the branch has
      * already been deleted:
-     *  "UnhandledPromiseRejectionWarning: HttpError: Reference does not exist" if branch already deleted.
+     *  HttpError: Reference does not exist"
      */
     if (calcIsGitHub(data)) {
       try {

--- a/controllers/handlePR.js
+++ b/controllers/handlePR.js
@@ -92,11 +92,6 @@ module.exports = async (repo, data) => {
         staticman.setConfigPath(parsedBody.configPath)
 
         await staticman.processMerge(parsedBody.fields, parsedBody.options)
-        // staticman.processMerge(parsedBody.fields, parsedBody.options).then(data => {
-        //   if (ua) {
-        //     ua.event('Hooks', 'Create/notify mailing list').send()
-        //   }
-        // })
         if (ua) {
           ua.event('Hooks', 'Create/notify mailing list').send()
         }
@@ -116,17 +111,6 @@ module.exports = async (repo, data) => {
      *  "UnhandledPromiseRejectionWarning: HttpError: Reference does not exist" if branch already deleted.
      */
     if (calcIsGitHub(data)) {
-      // await gitService.deleteBranch(review.sourceBranch).then(data => {
-      //   if (ua) {
-      //     ua.event('Hooks', 'Delete branch').send()
-      //   }
-      // }).catch(err => {
-      //   if (ua) {
-      //     ua.event('Hooks', 'Delete branch error').send()
-      //   }
-
-      //   return Promise.reject(err)
-      // })
       try {
         await gitService.deleteBranch(review.sourceBranch)
         if (ua) {

--- a/controllers/webhook.js
+++ b/controllers/webhook.js
@@ -38,12 +38,6 @@ module.exports = async (req, res, next) => {
               console.error(error.stack || error)
               errorMsg = error.message
             })
-            // try {
-            //   await handlePR(req.params.repository, req.body)
-            // } catch (error) {
-            //   console.error(error.stack || error)
-            //   errorMsg = error.message
-            // }
           }
         }
       }

--- a/controllers/webhook.js
+++ b/controllers/webhook.js
@@ -1,20 +1,70 @@
 'use strict'
 
+const path = require('path')
+const config = require(path.join(__dirname, '/../config'))
 const handlePR = require('./handlePR')
 
 module.exports = async (req, res, next) => {
   switch (req.params.service) {
     case 'gitlab':
-      handlePR(req.params.repository, req.body)
+      let errorMsg = null
+      let event = req.headers['x-gitlab-event']
 
-      res.status(200).send({
-        success: true
-      })
+      if (!event) {
+        errorMsg = 'No event found in the request'
+      } else {
+        if (event === 'Merge Request Hook') {
+          const webhookSecretExpected = config.get('gitlabWebhookSecret')
+          const webhookSecretSent = req.headers['x-gitlab-token']
+
+          let reqAuthenticated = true
+          if (webhookSecretExpected) {
+            reqAuthenticated = false
+            if (!webhookSecretSent) {
+              errorMsg = 'No secret found in the webhook request'
+            } else if (webhookSecretExpected === webhookSecretSent) {
+              /*
+               * Whereas GitHub uses the webhook secret to sign the request body, GitLab does not.
+               * As such, just check that the received secret equals the expected value.
+               */
+              reqAuthenticated = true
+            } else {
+              errorMsg = 'Unable to verify authenticity of request'
+            }
+          }
+
+          if (reqAuthenticated) {
+            await handlePR(req.params.repository, req.body).catch((error) => {
+              console.error(error.stack || error)
+              errorMsg = error.message
+            })
+            // try {
+            //   await handlePR(req.params.repository, req.body)
+            // } catch (error) {
+            //   console.error(error.stack || error)
+            //   errorMsg = error.message
+            // }
+          }
+        }
+      }
+
+      if (errorMsg !== null) {
+        res.status(400).send({
+          error: errorMsg
+        })
+      } else {
+        res.status(200).send({
+          success: true
+        })
+      }
 
       break
     default:
-      res.status(500).send({
-        error: 'Unexpected service found.'
+      res.status(400).send({
+        /*
+         * We are expecting GitHub webhooks to be handled by the express-github-webhook module.
+         */
+        error: 'Unexpected service specified.'
       })
   }
 }

--- a/controllers/webhook.js
+++ b/controllers/webhook.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const handlePR = require('./handlePR')
+
+module.exports = async (req, res, next) => {
+  switch (req.params.service) {
+    case 'gitlab':
+      handlePR(req.params.repository, req.body)
+
+      res.status(200).send({
+        success: true
+      })
+
+      break
+    default:
+      res.status(500).send({
+        error: 'Unexpected service found.'
+      })
+  }
+}

--- a/lib/GitHub.js
+++ b/lib/GitHub.js
@@ -19,7 +19,12 @@ class GitHub extends GitService {
       const isAppAuth = config.get('githubAppID') &&
         config.get('githubPrivateKey')
       const isLegacyAuth = config.get('githubToken') &&
-        ['1', '2'].includes(options.version)
+        /*
+         * Allowing/requiring the Staticman version to bleed-through to here is problematic, as
+         * it may not always be available to the caller (e.g., controllers/handlePR.js). To allow
+         * for this, we allow for a blank version value.
+         */
+        ['1', '2', ''].includes(options.version)
 
       let authToken
 

--- a/server.js
+++ b/server.js
@@ -145,7 +145,7 @@ class StaticmanAPI {
       webhookHandler.on('pull_request', handlePrWrapper)
 
       /*
-       * Explicit handler for errors raised inside the express-github-webhook module that mimmicks 
+       * Explicit handler for errors raised inside the express-github-webhook module that mimmicks
        * the system/express error handler. But, allows for customization and debugging.
        */
       webhookHandler.on('error', (error) => console.error(error.stack || error))

--- a/server.js
+++ b/server.js
@@ -134,15 +134,21 @@ class StaticmanAPI {
        */
       const handlePrWrapper = function (repo, data) {
         this.controllers.handlePR(repo, data).catch((error) => {
-          console.error(error)
           /*
            * Unfortunately, the express-github-webhook module returns a 200 (success) regardless
            * of any errors raised in the downstream handler. So, all we can do is log errors.
            */
+          console.error(error)
         })
       }.bind(this)
 
       webhookHandler.on('pull_request', handlePrWrapper)
+
+      /*
+       * Explicit handler for errors raised inside the express-github-webhook module that mimmicks 
+       * the system/express error handler. But, allows for customization and debugging.
+       */
+      webhookHandler.on('error', (error) => console.error(error.stack || error))
 
       this.server.use(webhookHandler)
     }

--- a/test/unit/controllers/handlePR.test.js
+++ b/test/unit/controllers/handlePR.test.js
@@ -27,9 +27,11 @@ beforeEach(() => {
 })
 
 describe('HandlePR controller', () => {
-  test('ignores pull requests from branches not prefixed with `staticman_`', async () => {
-    const pr = {
-      number: 123,
+  test.each([
+    ['github'],
+    ['gitlab'],
+  ])('ignores pull requests from branches not prefixed with `staticman_` - %s', async (service) => {
+    let pr = {
       title: 'Some random PR',
       body: 'Unrelated review body',
       head: {
@@ -40,35 +42,31 @@ describe('HandlePR controller', () => {
       },
       merged: false,
       repository: {
-        name: req.params.repository,
-        owner: {
-          login: req.params.username
-        }
+        name: req.params.repository
       },
       state: 'open'
     }
+    modifyPrDataForService(pr, service, req)
 
     const mockReview = new Review(pr.title, pr.body, 'false', pr.head.ref, pr.base.ref)
-    const mockGetReview = jest.fn().mockResolvedValue(mockReview)
+    const mockGetReviewGitHub = jest.fn().mockResolvedValue(mockReview)
+    const mockGetReviewGitLab = jest.fn().mockResolvedValue(mockReview)
 
-    jest.mock('../../../lib/GitHub', () => {
-      return jest.fn().mockImplementation(() => {
-        return {
-          getReview: mockGetReview
-        }
-      })
-    })
+    mockGitModules(mockGetReviewGitHub, mockGetReviewGitLab)
 
     const handlePR = require('./../../../controllers/handlePR')
 
     let response = await handlePR(req.params.repository, pr)
-    expect(mockGetReview).toHaveBeenCalledTimes(1)
+    assertGetReviewCalls(service, mockGetReviewGitHub, mockGetReviewGitLab)
     expect(response).toBe(null)
   })
 
   describe('processes notifications if the pull request has been merged', () => {
-    test('do nothing if PR body doesn\'t match template', async () => {
-      const pr = {
+    test.each([
+      ['github'],
+      ['gitlab'],
+    ])('do nothing if PR body doesn\'t match template - %s', async (service) => {
+      let pr = {
         number: 123,
         title: 'Add Staticman data',
         body: sampleData.prBody2,
@@ -87,29 +85,27 @@ describe('HandlePR controller', () => {
         },
         state: 'open'
       }
+      modifyPrDataForService(pr, service, req)
       
       const mockReview = new Review(pr.title, pr.body, 'false', pr.head.ref, pr.base.ref)
-      const mockGetReview = jest.fn().mockResolvedValue(mockReview)
+      const mockGetReviewGitHub = jest.fn().mockResolvedValue(mockReview)
+      const mockGetReviewGitLab = jest.fn().mockResolvedValue(mockReview)
       const mockDeleteBranch = jest.fn()
 
-      jest.mock('../../../lib/GitHub', () => {
-        return jest.fn().mockImplementation(() => {
-          return {
-            getReview: mockGetReview,
-            deleteBranch: mockDeleteBranch
-          }
-        })
-      })
+      mockGitModules(mockGetReviewGitHub, mockGetReviewGitLab, mockDeleteBranch)
 
       const handlePR = require('./../../../controllers/handlePR')
 
       await handlePR(req.params.repository, pr)
-      expect(mockGetReview).toHaveBeenCalledTimes(1)
+      assertGetReviewCalls(service, mockGetReviewGitHub, mockGetReviewGitLab)
       expect(mockDeleteBranch).not.toHaveBeenCalled()
     })
 
-    test('abort and return an error if `processMerge` fails', async () => {
-      const pr = {
+    test.each([
+      ['github'],
+      ['gitlab'],
+    ])('abort and return an error if `processMerge` fails - %s', async (service) => {
+      let pr = {
         number: 123,
         title: 'Add Staticman data',
         body: sampleData.prBody1,
@@ -128,19 +124,14 @@ describe('HandlePR controller', () => {
         },
         state: 'closed'
       }
+      modifyPrDataForService(pr, service, req)
       
       const mockReview = new Review(pr.title, pr.body, 'merged', pr.head.ref, pr.base.ref)
-      const mockGetReview = jest.fn().mockResolvedValue(mockReview)
+      const mockGetReviewGitHub = jest.fn().mockResolvedValue(mockReview)
+      const mockGetReviewGitLab = jest.fn().mockResolvedValue(mockReview)
       const mockDeleteBranch = jest.fn()
 
-      jest.mock('../../../lib/GitHub', () => {
-        return jest.fn().mockImplementation(() => {
-          return {
-            getReview: mockGetReview,
-            deleteBranch: mockDeleteBranch
-          }
-        })
-      })
+      mockGitModules(mockGetReviewGitHub, mockGetReviewGitLab, mockDeleteBranch)
 
       const errorMessage = 'some error'
 
@@ -150,12 +141,12 @@ describe('HandlePR controller', () => {
 
       const handlePR = require('./../../../controllers/handlePR')
 
-      expect.assertions(4)
+      expect.assertions(5)
       try {
         await handlePR(req.params.repository, pr)
       } catch (e) {
         expect(e).toBe(errorMessage)
-        expect(mockGetReview).toHaveBeenCalledTimes(1)
+        assertGetReviewCalls(service, mockGetReviewGitHub, mockGetReviewGitLab)
         // expect(mockSetConfigPathFn.mock.calls.length).toBe(1)
         // expect(mockProcessMergeFn.mock.calls.length).toBe(1)
         expect(mockSetConfigPathFn).toHaveBeenCalledTimes(1)
@@ -163,8 +154,11 @@ describe('HandlePR controller', () => {
       }
     })
 
-    test('delete the branch if the pull request is closed', async () => {
-      const pr = {
+    test.each([
+      ['github'],
+      ['gitlab'],
+    ])('delete the branch if the pull request is closed - %s', async (service) => {
+      let pr = {
         number: 123,
         title: 'Add Staticman data',
         body: sampleData.prBody1,
@@ -183,28 +177,90 @@ describe('HandlePR controller', () => {
         },
         state: 'closed'
       }
+      modifyPrDataForService(pr, service, req)
 
       const mockReview = new Review(pr.title, pr.body, 'merged', pr.head.ref, pr.base.ref)
       const mockDeleteBranch = jest.fn()
-      const mockGetReview = jest.fn().mockResolvedValue(mockReview)
+      const mockGetReviewGitHub = jest.fn().mockResolvedValue(mockReview)
+      const mockGetReviewGitLab = jest.fn().mockResolvedValue(mockReview)
 
-      jest.mock('../../../lib/GitHub', () => {
-        return jest.fn().mockImplementation(() => {
-          return {
-            deleteBranch: mockDeleteBranch,
-            getReview: mockGetReview
-          }
-        })
-      })
+      mockGitModules(mockGetReviewGitHub, mockGetReviewGitLab, mockDeleteBranch)
 
       const handlePR = require('./../../../controllers/handlePR')
 
       await handlePR(req.params.repository, pr)
-      expect(mockGetReview).toHaveBeenCalledTimes(1)
-      expect(mockGetReview.mock.calls[0][0]).toEqual(123)
-      expect(mockDeleteBranch).toHaveBeenCalledTimes(1)
+      assertGetReviewCalls(service, mockGetReviewGitHub, mockGetReviewGitLab)
+      if (service === 'github') {
+        expect(mockGetReviewGitHub.mock.calls[0][0]).toEqual(123)
+        expect(mockDeleteBranch).toHaveBeenCalledTimes(1)
+      } else if (service === 'gitlab') {
+        expect(mockGetReviewGitLab.mock.calls[0][0]).toEqual(123)
+        expect(mockDeleteBranch).toHaveBeenCalledTimes(0)
+      }
       expect(mockSetConfigPathFn.mock.calls.length).toBe(1)
       expect(mockProcessMergeFn.mock.calls.length).toBe(1)
     })
   })
 })
+
+/**
+ * Avoid code duplication in the above test cases.
+ */
+const modifyPrDataForService = function (prData, service, req) {
+  if (service === 'github') {
+    prData.number = 123
+    prData.repository.url = 'https://api.github.com/repos/' + req.params.username + '/' + req.params.repository
+    prData.repository.owner = {
+      login: req.params.username
+    }
+  } else if (service === 'gitlab') {
+    prData.object_attributes = {
+      iid: 123
+    }
+    prData.repository.url = 'git@gitlab.com:' + req.params.username + '/' + req.params.repository + '.git'
+    prData.user = {
+      username: req.params.username
+    }
+  }
+}
+
+/**
+ * Avoid code duplication in the above test cases.
+ */
+const mockGitModules = function (mockGetReviewGitHub, mockGetReviewGitLab, mockDeleteBranch) {
+  jest.mock('../../../lib/GitHub', () => {
+    return jest.fn().mockImplementation(() => {
+      let result = {
+        getReview: mockGetReviewGitHub, 
+      }
+      if (mockDeleteBranch) {
+        result.deleteBranch = mockDeleteBranch
+      }
+      return result
+    })
+  })
+  jest.mock('../../../lib/GitLab', () => {
+    return jest.fn().mockImplementation(() => {
+      let result = {
+        getReview: mockGetReviewGitLab, 
+      }
+      if (mockDeleteBranch) {
+        result.deleteBranch = mockDeleteBranch
+      }
+      return result
+    })
+  })
+}
+
+/**
+ * Avoid code duplication in the above test cases.
+ */
+const assertGetReviewCalls = function (service, mockGetReviewGitHub, mockGetReviewGitLab) {
+  if (service === 'github') {
+    expect(mockGetReviewGitHub).toHaveBeenCalledTimes(1)
+    expect(mockGetReviewGitLab).toHaveBeenCalledTimes(0)
+  } else if (service === 'gitlab') {
+    expect(mockGetReviewGitHub).toHaveBeenCalledTimes(0)
+    expect(mockGetReviewGitLab).toHaveBeenCalledTimes(1)
+  }
+}

--- a/test/unit/controllers/handlePR.test.js
+++ b/test/unit/controllers/handlePR.test.js
@@ -231,7 +231,7 @@ const mockGitModules = function (mockGetReviewGitHub, mockGetReviewGitLab, mockD
   jest.mock('../../../lib/GitHub', () => {
     return jest.fn().mockImplementation(() => {
       let result = {
-        getReview: mockGetReviewGitHub, 
+        getReview: mockGetReviewGitHub
       }
       if (mockDeleteBranch) {
         result.deleteBranch = mockDeleteBranch
@@ -242,7 +242,7 @@ const mockGitModules = function (mockGetReviewGitHub, mockGetReviewGitLab, mockD
   jest.mock('../../../lib/GitLab', () => {
     return jest.fn().mockImplementation(() => {
       let result = {
-        getReview: mockGetReviewGitLab, 
+        getReview: mockGetReviewGitLab
       }
       if (mockDeleteBranch) {
         result.deleteBranch = mockDeleteBranch

--- a/test/unit/controllers/webhook.test.js
+++ b/test/unit/controllers/webhook.test.js
@@ -1,0 +1,172 @@
+const config = require('./../../../config')
+const helpers = require('./../../helpers')
+
+let req
+let res
+
+let mockHandlePrFn = jest.fn()
+// The handlePR module exposes one "naked" function.
+jest.mock('../../../controllers/handlePR', () => {
+  return mockHandlePrFn
+});
+
+const webhook = require('./../../../controllers/webhook')
+
+beforeEach(() => {
+  mockHandlePrFn.mockImplementation(() => Promise.resolve('success'))
+  // mockHandlePrFn.mockImplementation(() => {
+  //   return 'success'
+  // })
+
+  req = helpers.getMockRequest()
+  res = helpers.getMockResponse()
+})
+
+afterEach(() => {
+  // Clear any test-specific mock implementations.
+  mockHandlePrFn.mockClear()
+})
+
+describe('Webhook controller', () => {
+  test.each([
+    ['github']
+  ])('returns an error if GitHub specified', async (service) => {
+    req.params.service = service
+
+    expect.hasAssertions()
+    return webhook(req, res).then(response => {
+      expect(mockHandlePrFn).toHaveBeenCalledTimes(0)
+      expect(res.send.mock.calls[0][0]).toEqual({ error: 'Unexpected service specified.' })
+      expect(res.status.mock.calls[0][0]).toBe(400)
+    })
+  })
+
+  test.each([
+    ['gitlab']
+  ])('abort and return an error if no event header found  - %s', async (service) => {
+    req.params.service = service
+
+    expect.hasAssertions()
+    return webhook(req, res).then(response => {
+      expect(mockHandlePrFn).toHaveBeenCalledTimes(0)
+      expect(res.send.mock.calls[0][0]).toEqual({ error: 'No event found in the request' })
+      expect(res.status.mock.calls[0][0]).toBe(400)
+    })
+  })
+
+  test.each([
+    ['gitlab']
+  ])('abort and return success if not "Merge Request Hook" event - %s', async (service) => {
+    req.params.service = service
+    req.headers['x-gitlab-event'] = 'Some Other Hook'
+
+    expect.hasAssertions()
+    return webhook(req, res).then(response => {
+      expect(mockHandlePrFn).toHaveBeenCalledTimes(0)
+      expect(res.status.mock.calls[0][0]).toBe(200)
+    })
+  })
+
+  test.each([
+    ['gitlab']
+  ])('abort and return an error if "handlePR" call fails  - %s', async (service) => {
+    req.params.service = service
+    req.headers['x-gitlab-event'] = 'Merge Request Hook'
+
+    /*
+     * Replace the mock implementation to throw an error. More info: 
+     *  https://blog.bguiz.com/2017/mocking-chained-apis-jest/
+     */
+    mockHandlePrFn.mockImplementation(() => Promise.reject( { message: 'Error calling handlePR.' } ))
+    // mockHandlePrFn.mockImplementation(() => {
+    //   throw { message: 'Error calling handlePR.' }
+    // })
+
+    // Suppress any calls to console.error - to keep test output clean.
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect.hasAssertions()
+    return webhook(req, res).then(response => {
+      expect(mockHandlePrFn).toHaveBeenCalledTimes(1)
+      expect(res.send.mock.calls[0][0]).toEqual({ error: 'Error calling handlePR.' })
+      expect(res.status.mock.calls[0][0]).toBe(400)
+
+      // Restore console.error
+      consoleSpy.mockRestore();
+    })
+  })
+
+  test.each([
+    ['gitlab']
+  ])('return success if "handlePR" call succeeds  - %s', async (service) => {
+    req.params.service = service
+    req.headers['x-gitlab-event'] = 'Merge Request Hook'
+
+    expect.hasAssertions()
+    return webhook(req, res).then(response => {
+      expect(mockHandlePrFn).toHaveBeenCalledTimes(1)
+      expect(res.status.mock.calls[0][0]).toBe(200)
+    })
+  })
+
+  test.each([
+    ['gitlab']
+  ])('abort and return an error if webhook secret not sent  - %s', async (service) => {
+    req.params.service = service
+    req.headers['x-gitlab-event'] = 'Merge Request Hook'
+
+    // Inject a value for "gitlabWebhookSecret" into the JSON-sourced config.
+    config.set('gitlabWebhookSecret', '2a-foobar-db72')
+
+    expect.hasAssertions()
+    return webhook(req, res).then(response => {
+      expect(mockHandlePrFn).toHaveBeenCalledTimes(0)
+      expect(res.send.mock.calls[0][0]).toEqual({ error: 'No secret found in the webhook request' })
+      expect(res.status.mock.calls[0][0]).toBe(400)
+
+      // Clean-up the modified JSON-sourced config.
+      config.set('gitlabWebhookSecret', null)
+    })
+  })
+
+  test.each([
+    ['gitlab']
+  ])('abort and return an error if unexpected webhook secret sent  - %s', async (service) => {
+    req.params.service = service
+    req.headers['x-gitlab-event'] = 'Merge Request Hook'
+    req.headers['x-gitlab-token'] = '2a-different-db72'
+
+    // Inject a value for "gitlabWebhookSecret" into the JSON-sourced config.
+    config.set('gitlabWebhookSecret', '2a-foobar-db72')
+
+    expect.hasAssertions()
+    return webhook(req, res).then(response => {
+      expect(mockHandlePrFn).toHaveBeenCalledTimes(0)
+      expect(res.send.mock.calls[0][0]).toEqual({ error: 'Unable to verify authenticity of request' })
+      expect(res.status.mock.calls[0][0]).toBe(400)
+
+      // Clean-up the modified JSON-sourced config.
+      config.set('gitlabWebhookSecret', null)
+    })
+  })
+
+  test.each([
+    ['gitlab']
+  ])('return success if expected webhook secret sent  - %s', async (service) => {
+    req.params.service = service
+    req.headers['x-gitlab-event'] = 'Merge Request Hook'
+    req.headers['x-gitlab-token'] = '2a-foobar-db72'
+
+    // Inject a value for "gitlabWebhookSecret" into the JSON-sourced config.
+    config.set('gitlabWebhookSecret', '2a-foobar-db72')
+
+    expect.hasAssertions()
+    return webhook(req, res).then(response => {
+      expect(mockHandlePrFn).toHaveBeenCalledTimes(1)
+      expect(res.status.mock.calls[0][0]).toBe(200)
+
+      // Clean-up the modified JSON-sourced config.
+      config.set('gitlabWebhookSecret', null)
+    })
+  })
+})

--- a/test/unit/controllers/webhook.test.js
+++ b/test/unit/controllers/webhook.test.js
@@ -74,7 +74,7 @@ describe('Webhook controller', () => {
     req.headers['x-gitlab-event'] = 'Merge Request Hook'
 
     /*
-     * Replace the mock implementation to throw an error. More info: 
+     * Replace the mock implementation to throw an error. More info:
      *  https://blog.bguiz.com/2017/mocking-chained-apis-jest/
      */
     mockHandlePrFn.mockImplementation(() => Promise.reject( { message: 'Error calling handlePR.' } ))

--- a/test/unit/lib/GitHub.test.js
+++ b/test/unit/lib/GitHub.test.js
@@ -37,6 +37,22 @@ describe('GitHub interface', () => {
     expect(scope.isDone()).toBe(true)
   })
 
+  test('authenticates with the GitHub API using a personal access token when version blank', async () => {
+    const scope = nock((/api\.github\.com/), {
+      reqheaders: {
+        authorization: 'token '.concat('1q2w3e4r')
+      }
+    })
+      .get('/user/repository_invitations')
+      .reply(200)
+
+    let paramsWithoutVersion = Object.assign({}, req.params)
+    paramsWithoutVersion.version = ''
+    const githubInstance = await new GitHub(paramsWithoutVersion)
+    await githubInstance.api.repos.listInvitationsForAuthenticatedUser();
+    expect(scope.isDone()).toBe(true)
+  })
+
   test('authenticates with the GitHub API using an OAuth token', async () => {
     const scope = nock((/api\.github\.com/), {
       reqheaders: {


### PR DESCRIPTION
The main thrust of these modifications is to enable the sending of email notifications to comment subscribers when the backing git service is GitLab (as opposed to GitHub).

I see that @OlafHaag mentioned this as being an issue in 2019: 
https://github.com/eduardoboucas/staticman/issues/22#issuecomment-473752430

My understanding of the history of this issue is that when @ntsim added GitLab support to the codebase in 2018, they left the webhook endpoint untouched. This was because, in GitLab, merge requests are set to automatically close the source branch: 
https://github.com/eduardoboucas/staticman/pull/219

However, it looks like @eduardoboucas added in support for sending email notifications (via webhook) as far back as 2016: 
https://github.com/eduardoboucas/staticman/issues/42#issuecomment-262938831

Not sure why the miss, but these modifications address it, regardless.

Staticman v3 service-specific `webhook` endpoints have been added (i.e., `/v3/webhook/github` and `/v3/webhook/gitlab`). In the corresponding code, support has been added for webhook request authentication, which may be configured via the JSON config. This amounts to allowing for `gitlabWebhookSecret` and `githubWebhookSecret` properties to be set, thereby triggering webhook request authentication for GitHub and/or GitLab. If either secret is configured in Staticman, but missing from the webhook calls (or not valued as expected), an error is thrown.

This also addresses https://github.com/eduardoboucas/staticman/issues/389

**Update**: The webhook request authentication functionality introduced here is further refined in https://github.com/hispanic/staticwoman/pull/8
