### PR TITLE
Allow for giving notification mailing lists a name

### DIFF
--- a/lib/Notification.js
+++ b/lib/Notification.js
@@ -28,12 +28,22 @@ Notification.prototype.send = function (to, fields, options, data) {
   const subject = data.siteName ? `New reply on "${data.siteName}"` : 'New reply'
 
   return new Promise((resolve, reject) => {
-    this.mailAgent.messages().send({
+    let payload = {
       from: `Staticman <${config.get('email.fromAddress')}>`,
       to,
       subject,
       html: this._buildMessage(fields, options, data)
-    }, (err, res) => {
+    }
+    /*
+     * If we set the "reply_preference" property on the Mailgun mailing list to "sender" (which
+     * seems to be the safest and most appropriate option for a list meant to receive
+     * notifications), the "reply-to" of every email sent via the mailing list will be
+     * postmaster@[mailgun domain] instead of the "from" address set above. Defeat this by
+     * explicitly setting the "h:Reply-To" header.
+     */
+    payload['h:Reply-To'] = payload.from
+
+    this.mailAgent.messages().send(payload, (err, res) => {
       if (err) {
         return reject(err)
       }

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -534,7 +534,7 @@ class Staticman {
 
       // Subscribe user, if applicable
       if (subscriptions && options.parent && options.subscribe && this.fields[options.subscribe]) {
-        subscriptions.set(options.parent, this.fields[options.subscribe]).catch(err => {
+        subscriptions.set(options, this.fields[options.subscribe]).catch(err => {
           console.log(err.stack || err)
         })
       }

--- a/lib/SubscriptionsManager.js
+++ b/lib/SubscriptionsManager.js
@@ -45,7 +45,8 @@ SubscriptionsManager.prototype.send = function (entryId, fields, options, siteCo
   })
 }
 
-SubscriptionsManager.prototype.set = function (entryId, email) {
+SubscriptionsManager.prototype.set = function (options, email) {
+  const entryId = options.parent
   const listAddress = this._getListAddress(entryId)
 
   return new Promise((resolve, reject) => {
@@ -54,9 +55,35 @@ SubscriptionsManager.prototype.set = function (entryId, email) {
     return this._get(entryId).then(list => {
       if (!list) {
         queue.push(new Promise((resolve, reject) => {
-          this.mailAgent.lists().create({
+          let payload = {
             address: listAddress
-          }, (err, result) => {
+          }
+          /*
+           * Only allow authenticated users to post to the list. This is the default, but let's
+           * explicitly set it in case the default changes.
+           */
+          payload.access_level = 'readonly'
+
+          /*
+           * Restricting replies to "sender" (as opposed to all members of the list) would seem
+           * to be the safest and most appropriate option for a list meant to receive
+           * notifications.
+           */
+          payload.reply_preference = 'sender'
+
+          const entryName = options.parentName
+          if (typeof entryName !== 'undefined') {
+            /*
+             * Set a name and description on the created list to aid in identification and
+             * troubleshooting, as the automatically-generated list address is an obfuscated
+             * hash value.
+             */
+            payload.name = entryName
+            payload.description = 'Subscribers to: ' + entryName +
+              ' (' + this.parameters.username + '/' + this.parameters.repository + ')'
+          }
+
+          this.mailAgent.lists().create(payload, (err, result) => {
             if (err) return reject(err)
 
             return resolve(result)
@@ -74,6 +101,8 @@ SubscriptionsManager.prototype.set = function (entryId, email) {
           return resolve(result)
         })
       })
+    }).catch(error => {
+      reject(error)
     })
   })
 }

--- a/test/unit/lib/Notification.test.js
+++ b/test/unit/lib/Notification.test.js
@@ -52,7 +52,7 @@ describe('Notification interface', () => {
     expect(mockSendFn.mock.calls.length).toBe(1)
     expect(mockSendFn.mock.calls[0][0]).toEqual({
       from: `Staticman <${config.get('email.fromAddress')}>`,
-      'h:Reply-To': `Staticman <${config.get('email.fromAddress')}>`, 
+      'h:Reply-To': `Staticman <${config.get('email.fromAddress')}>`,
       to: recipient,
       subject: `New reply on "${mockData.data.siteName}"`,
       html: message

--- a/test/unit/lib/Notification.test.js
+++ b/test/unit/lib/Notification.test.js
@@ -52,6 +52,7 @@ describe('Notification interface', () => {
     expect(mockSendFn.mock.calls.length).toBe(1)
     expect(mockSendFn.mock.calls[0][0]).toEqual({
       from: `Staticman <${config.get('email.fromAddress')}>`,
+      'h:Reply-To': `Staticman <${config.get('email.fromAddress')}>`, 
       to: recipient,
       subject: `New reply on "${mockData.data.siteName}"`,
       html: message

--- a/test/unit/lib/Staticman.test.js
+++ b/test/unit/lib/Staticman.test.js
@@ -1529,7 +1529,7 @@ describe('Staticman interface', () => {
         fields,
         options
       ).then(response => {
-        expect(mockSubscriptionSet.mock.calls[0][0]).toBe(options.parent)
+        expect(mockSubscriptionSet.mock.calls[0][0]).toEqual(options)
         expect(mockSubscriptionSet.mock.calls[0][1]).toBe(mockHelpers.getFields().email)
       })
     })

--- a/test/unit/lib/SubscriptionsManager.test.js
+++ b/test/unit/lib/SubscriptionsManager.test.js
@@ -3,7 +3,7 @@
 const SubscriptionsManager = require('./../../../lib/SubscriptionsManager')
 
 let params = {
-	username: 'foo-user', 
+	username: 'foo-user',
 	repository: 'foo-repo'
 }
 const dataStore = null
@@ -20,8 +20,8 @@ beforeEach(() => {
   mockMailAgent = {
 	lists: jest.fn().mockImplementation(listaddr => {
 	  const result = {
-		info: mockListsInfoFunc, 
-		create: mockListsCreateFunc, 
+		info: mockListsInfoFunc,
+		create: mockListsCreateFunc,
 		members: jest.fn().mockImplementation(() => {
 		  const result = {
 			create: mockListsMembersCreateFunc

--- a/test/unit/lib/SubscriptionsManager.test.js
+++ b/test/unit/lib/SubscriptionsManager.test.js
@@ -1,0 +1,173 @@
+
+
+const SubscriptionsManager = require('./../../../lib/SubscriptionsManager')
+
+let params = {
+	username: 'foo-user', 
+	repository: 'foo-repo'
+}
+const dataStore = null
+
+let mockListsInfoFunc = jest.fn()
+let mockListsCreateFunc = jest.fn()
+let mockListsMembersCreateFunc = jest.fn()
+let mockMailAgent
+
+let options
+const emailAddr = 'foo@example.com'
+
+beforeEach(() => {
+  mockMailAgent = {
+	lists: jest.fn().mockImplementation(listaddr => {
+	  const result = {
+		info: mockListsInfoFunc, 
+		create: mockListsCreateFunc, 
+		members: jest.fn().mockImplementation(() => {
+		  const result = {
+			create: mockListsMembersCreateFunc
+		  }
+		  return result
+		})
+	  }
+	  return result
+	}), 
+	domain: 'example.com'
+  }
+
+  options = {
+	parent: 'an-awesome-post-about-staticman'
+  }
+})
+
+afterEach(() => {
+  mockMailAgent.lists.mockClear()
+  mockListsInfoFunc.mockClear()
+  mockListsCreateFunc.mockClear()
+  mockListsMembersCreateFunc.mockClear()
+})
+
+describe('SubscriptionsManager', () => {
+  test('creates mailing list if it does not exist and adds subscriber', async () => {
+    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+    // Mock that the list does not exist.
+    mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
+    mockListsCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success') )
+    mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
+
+    expect.hasAssertions()
+    await subscriptionsMgr.set(options, emailAddr).then(response => {
+      expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
+      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+      expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
+      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
+      expect(mockMailAgent.lists.mock.calls[0][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+      expect(mockListsCreateFunc.mock.calls[0][0]['address']).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+      expect(mockListsCreateFunc.mock.calls[0][0]['access_level']).toBe('readonly')
+      expect(mockListsCreateFunc.mock.calls[0][0]['reply_preference']).toBe('sender')
+      expect(mockListsMembersCreateFunc.mock.calls[0][0]).toEqual( { address: emailAddr } )
+    })
+  })
+
+  test('creates mailing list (with name and description) if it does not exist and adds subscriber', async () => {
+    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+    // Mock that the list does not exist.
+    mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
+    mockListsCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success') )
+    mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
+
+    // Set the optional parent name.
+    options.parentName = 'Post an-awesome-post-about-staticman'
+
+    expect.hasAssertions()
+    await subscriptionsMgr.set(options, emailAddr).then(response => {
+      expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
+      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+      expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
+      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
+      expect(mockMailAgent.lists.mock.calls[0][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+      expect(mockListsCreateFunc.mock.calls[0][0]['address']).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+      expect(mockListsCreateFunc.mock.calls[0][0]['access_level']).toBe('readonly')
+      expect(mockListsCreateFunc.mock.calls[0][0]['reply_preference']).toBe('sender')
+      // Assert that "name" and "description" are passed when parent name is supplied.
+      expect(mockListsCreateFunc.mock.calls[0][0]['name']).toBe(options.parentName)
+      expect(mockListsCreateFunc.mock.calls[0][0]['description']).toBe(
+      	'Subscribers to: ' + options.parentName + ' (' + params.username + '/' + params.repository + ')')
+      expect(mockListsMembersCreateFunc.mock.calls[0][0]).toEqual( { address: emailAddr } )
+    })
+  })
+
+  test('does not create mailing list if it already exists and adds subscriber', async () => {
+    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+    // Mock that the list exists.
+    mockListsInfoFunc.mockImplementation( (callback) => callback(null, {list: {}}) )
+    mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
+
+    expect.hasAssertions()
+    await subscriptionsMgr.set(options, emailAddr).then(response => {
+      expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
+      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+      // Assert that list not created.
+      expect(mockListsCreateFunc).toHaveBeenCalledTimes(0)
+      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
+      expect(mockMailAgent.lists.mock.calls[0][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+      expect(mockListsMembersCreateFunc.mock.calls[0][0]).toEqual( { address: emailAddr } )
+    })
+  })
+
+  test('list lookup error handled', async () => {
+    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+    // Mock that the list lookup errors.
+    mockListsInfoFunc.mockImplementation( (callback) => 
+      callback({statusCode: 500, message: 'list lookup failure'}, null) )
+
+    expect.hasAssertions()
+    await subscriptionsMgr.set(options, emailAddr).catch(error => {
+      expect(error.message).toBe('list lookup failure')
+      expect(mockMailAgent.lists).toHaveBeenCalledTimes(1)
+      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+      expect(mockListsCreateFunc).toHaveBeenCalledTimes(0)
+      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  test('list create error handled', async () => {
+    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+    mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
+    // Mock that the list create errors.
+    mockListsCreateFunc.mockImplementation( (createData, callback) => 
+      callback({statusCode: 500, message: 'list create failure'}, null) )
+
+    expect.hasAssertions()
+    await subscriptionsMgr.set(options, emailAddr).catch(error => {
+      expect(error.message).toBe('list create failure')
+      expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
+      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+      expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
+      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  test('list member create error handled', async () => {
+    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+    mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
+    mockListsCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success') )
+    // Mock that the list member create errors.
+    mockListsMembersCreateFunc.mockImplementation( (createData, callback) => 
+      callback({statusCode: 500, message: 'member create failure'}, null) )
+
+    expect.hasAssertions()
+    await subscriptionsMgr.set(options, emailAddr).catch(error => {
+      expect(error.message).toBe('member create failure')
+      expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
+      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+      expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
+      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
+    })
+  })
+})


### PR DESCRIPTION
Addresses issue #127 - "Mailgun mailing lists - give each one a name"

I added support for passing in a new "parentName" option to the "entry" endpoint. You can set it to whatever value you prefer. For example: 
  - options[parentName] = Post "Staticman is Awesome"
  - options[parentName] = Post staticman-is-awesome
  - options[parentName] = Comment 88688c70-12d1-11eb-b135-db5a5177adbc
  - options[parentName] = Comment 88688c70-12d1-11eb-b135-db5a5177adbc on Post staticman-is-awesome
  - options[parentName] = Blog "Mike's Tech Thoughts"

I chose "parentName" intentionally, as I believe @eduardoboucas originally added the "parent" option as "a unique identifier to the entry the user is subscribing to." More info: https://github.com/eduardoboucas/staticman/issues/42#issuecomment-262938831

When supplied, this value will be used to populate the "name" property of the created mailing list in Mailgun. In addition, supplying this option will also trigger the population of the "description" property for the mailing list. The description will be of the following form: 
  - "Subscribers to: [parentName] ([repo-username]/[repo-name])

I have chosen to deliberately expose the relevant repository in the description, as that is factored into the creation of the mailing list ID.

If a "parentName" option is not passed, the mailing list will be created without a name or description, just as currently implemented.

As part of this change, I have modified the mailing list creation logic to set two other properties exposed by the Mailgun API:
  - Set "access_level" to "readonly". This will only allow authenticated users to post to the list. This is the Mailgun default, but I think it wise to explicitly set it in case the default changes.
  - Set "reply_preference" to "sender". Restricting replies to "sender" (as opposed to all members of the list) would seem to be the safest and most appropriate option for a list meant to receive notifications.

By setting the "reply_preference" property on the Mailgun mailing list to "sender", the "reply-to" of every email sent via the mailing list will be postmaster@[mailgun domain] instead of the "from" address (e.g., noreply@staticman.net). I defeat this by explicitly setting the "h:Reply-To" header (to be the same as the "from" address).