### PR TITLE
Allow for customizing the name of the sender to put on notification emails

### DIFF
--- a/config.js
+++ b/config.js
@@ -42,10 +42,16 @@ const schema = {
       env: 'EMAIL_DOMAIN'
     },
     fromAddress: {
-      doc: 'Email address to send notifications from. Will be overridden by a `notifications.fromAddress` parameter in the site config, if one is set.',
+      doc: 'Email address to send notifications from.',
       format: String,
       default: 'noreply@staticman.net',
       env: 'EMAIL_FROM'
+    },
+    fromName: {
+      doc: 'Name of the sender to put on notification emails.',
+      format: String,
+      default: 'Staticman',
+      env: 'EMAIL_FROM_NAME'
     }
   },
   env: {

--- a/lib/Notification.js
+++ b/lib/Notification.js
@@ -29,7 +29,7 @@ Notification.prototype.send = function (to, fields, options, data) {
 
   return new Promise((resolve, reject) => {
     let payload = {
-      from: `Staticman <${config.get('email.fromAddress')}>`,
+      from: `${config.get('email.fromName')} <${config.get('email.fromAddress')}>`,
       to,
       subject,
       html: this._buildMessage(fields, options, data)

--- a/test/unit/lib/Notification.test.js
+++ b/test/unit/lib/Notification.test.js
@@ -51,8 +51,8 @@ describe('Notification interface', () => {
 
     expect(mockSendFn.mock.calls.length).toBe(1)
     expect(mockSendFn.mock.calls[0][0]).toEqual({
-      from: `Staticman <${config.get('email.fromAddress')}>`,
-      'h:Reply-To': `Staticman <${config.get('email.fromAddress')}>`,
+      from: `${config.get('email.fromName')} <${config.get('email.fromAddress')}>`,
+      'h:Reply-To': `${config.get('email.fromName')} <${config.get('email.fromAddress')}>`,
       to: recipient,
       subject: `New reply on "${mockData.data.siteName}"`,
       html: message


### PR DESCRIPTION
This addresses issue https://github.com/eduardoboucas/staticman/issues/392 - "Provide support for customizing the name of the sender on notification emails".

The changes for this are minimal. 
  - I added a new email.fromName property to the JSON config schema. The default value is "Staticman".
  - I added a reference to this new property in Notification.js