### PR TITLE
Allow for customizing the content (and subject) of notification emails

### DIFF
--- a/controllers/handlePR.js
+++ b/controllers/handlePR.js
@@ -91,7 +91,7 @@ module.exports = async (repo, data) => {
 
         staticman.setConfigPath(parsedBody.configPath)
 
-        await staticman.processMerge(parsedBody.fields, parsedBody.options)
+        await staticman.processMerge(parsedBody.fields, parsedBody.extendedFields, parsedBody.options)
         if (ua) {
           ua.event('Hooks', 'Create/notify mailing list').send()
         }

--- a/email-notification-content.njk
+++ b/email-notification-content.njk
@@ -1,0 +1,17 @@
+{# 
+    This template may be modified to customize the content of emails sent to notify subscribers 
+    when new comments are added. Uses the Nunjucks templating language. More info - 
+    https://mozilla.github.io/nunjucks/ 
+#}
+<html>
+  <body>
+    Dear human,<br>
+    <br>
+    Someone replied to a comment you subscribed to{% if data.siteName %} on <strong>{{ data.siteName }}</strong>{% endif %}.<br>
+    <br>
+    {% if options.origin %}<a href="{{ options.origin }}">Click here</a> to see it. {% endif %}If you do not wish to receive any further notifications for this thread, <a href="%mailing_list_unsubscribe_url%">click here</a>.<br>
+    <br>
+    #ftw,<br>
+    -- <a href="https://staticman.net">Staticman</a>
+  </body>
+</html>

--- a/email-notification-content.njk
+++ b/email-notification-content.njk
@@ -1,7 +1,7 @@
-{# 
-    This template may be modified to customize the content of emails sent to notify subscribers 
-    when new comments are added. Uses the Nunjucks templating language. More info - 
-    https://mozilla.github.io/nunjucks/ 
+{#
+    This template may be modified to customize the content of emails sent to notify subscribers
+    when new comments are added. Uses the Nunjucks templating language. More info -
+    https://mozilla.github.io/nunjucks/
 #}
 <html>
   <body>

--- a/email-notification-subject.njk
+++ b/email-notification-subject.njk
@@ -1,0 +1,6 @@
+{# 
+    This template may be modified to customize the content of the subject line used in emails 
+    sent to notify subscribers when new comments are added. Uses the Nunjucks templating language. 
+    More info - https://mozilla.github.io/nunjucks/ 
+#}
+{% if data.siteName %}New reply on {{ data.siteName }}{% else %}New reply{% endif %}

--- a/email-notification-subject.njk
+++ b/email-notification-subject.njk
@@ -1,6 +1,6 @@
-{# 
-    This template may be modified to customize the content of the subject line used in emails 
-    sent to notify subscribers when new comments are added. Uses the Nunjucks templating language. 
-    More info - https://mozilla.github.io/nunjucks/ 
+{#
+    This template may be modified to customize the content of the subject line used in emails
+    sent to notify subscribers when new comments are added. Uses the Nunjucks templating language.
+    More info - https://mozilla.github.io/nunjucks/
 #}
 {% if data.siteName %}New reply on {{ data.siteName }}{% else %}New reply{% endif %}

--- a/lib/Notification.js
+++ b/lib/Notification.js
@@ -1,39 +1,97 @@
 'use strict'
 
+const fs = require('fs')
 const path = require('path')
+const util = require('util')
 const config = require(path.join(__dirname, '/../config'))
+const nunjucks = require('nunjucks')
+
+const readFileAsync = util.promisify(fs.readFile)
 
 const Notification = function (mailAgent) {
   this.mailAgent = mailAgent
 }
 
-Notification.prototype._buildMessage = function (fields, options, data) {
-  return `
-  <html>
-    <body>
-      Dear human,<br>
-      <br>
-      Someone replied to a comment you subscribed to${data.siteName ? ` on <strong>${data.siteName}</strong>` : ''}.<br>
-      <br>
-      ${options.origin ? `<a href="${options.origin}">Click here</a> to see it.` : ''} If you do not wish to receive any further notifications for this thread, <a href="%mailing_list_unsubscribe_url%">click here</a>.<br>
-      <br>
-      #ftw,<br>
-      -- <a href="https://staticman.net">Staticman</a>
-    </body>
-  </html>
-  `
+Notification.prototype._buildSubject = async function (fields, extendedFields, options, data) {
+  const templateContent = await this._loadEmailTemplate('subject',
+    `There is a new comment at {{ data.siteName }}`)
+  const subject = nunjucks.renderString(templateContent, {
+    fields: fields,
+    extendedFields: extendedFields,
+    options: options,
+    data: data
+  })
+  return subject
 }
 
-Notification.prototype.send = function (to, fields, options, data) {
-  const subject = data.siteName ? `New reply on "${data.siteName}"` : 'New reply'
+Notification.prototype._buildMessage = async function (fields, extendedFields, options, data) {
+  const templateContent = await this._loadEmailTemplate('content', `
+    <html>
+      <body>
+        <h2>There is a new comment at <a href="{{ options.origin }}">{{ options.origin }}</a>.</h2>
+        <br>
+        If you prefer, you may <a href="%mailing_list_unsubscribe_url%">unsubscribe</a> from future emails.<br>
+        <br>
+      </body>
+    </html>
+    `
+  )
+  const emailContent = nunjucks.renderString(templateContent, {
+    fields: fields,
+    extendedFields: extendedFields,
+    options: options,
+    data: data
+  })
+  return emailContent
+}
 
-  return new Promise((resolve, reject) => {
+Notification.prototype._loadEmailTemplate = async function (subjectOrContent, defaultResult) {
+  let templateContent = null
+  try {
+    /*
+     * Expect a Nunjucks template file to be found at the root of the codebase, available for
+     * customization.
+     */
+    templateContent = await readFileAsync(
+      path.join(__dirname, '/../email-notification-' + subjectOrContent + '.njk'), {
+        encoding: 'utf8'
+      })
+  } catch (error) {
+    console.error(error)
+    console.error('Sending notification email using default ' + subjectOrContent + '.')
+
+    templateContent = defaultResult
+  }
+  return templateContent
+}
+
+/**
+ * Send an email to the identified mailing list to notify the list member(s) that a new comment
+ * has been posted.
+ * @param to {String} - The address/ID of the mailing list to be targeted.
+ * @param fields {Object} - Simple mapping of "fields" key-value pairs gathered when the comment
+ *  was submitted, moderately processed. Mostly contains data provided by the commenter,
+ *  including the comment, comment author, and commenter email address (hashed). However, any
+ *  Staticman-generated comment date ends up in here, too.
+ * @param extendedFields {Object} - Simple mapping of key-value pairs generated when the comment
+ *  was submitted, fully processed. In addition to the data found in the "fields" parameter, also
+ *  includes the Staticman-generated comment ID.
+ * @param options {Object} - Simple mapping of "options" key-value pairs gathered when the comment
+ *  was submitted. Mostly metadata, including the origin site, ID of the comment's parent, etc.
+ * @param data {Object} - Simple mapping of key-value pairs containing any other pertinent data,
+ *  such as configuration parameters.
+ * return {Promise} - provided as part of submitting to the mailing list agent.
+ */
+Notification.prototype.send = function (to, fields, extendedFields, options, data) {
+  return new Promise(async (resolve, reject) => {
     let payload = {
       from: `${config.get('email.fromName')} <${config.get('email.fromAddress')}>`,
-      to,
-      subject,
-      html: this._buildMessage(fields, options, data)
+      to
     }
+
+    payload.subject = await this._buildSubject(fields, extendedFields, options, data)
+    payload.html = await this._buildMessage(fields, extendedFields, options, data)
+
     /*
      * If we set the "reply_preference" property on the Mailgun mailing list to "sender" (which
      * seems to be the safest and most appropriate option for a list meant to receive
@@ -45,6 +103,7 @@ Notification.prototype.send = function (to, fields, options, data) {
 
     this.mailAgent.messages().send(payload, (err, res) => {
       if (err) {
+        console.error(err)
         return reject(err)
       }
 

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -281,7 +281,7 @@ class Staticman {
     })
   }
 
-  _generateReviewBody (fields) {
+  _generateReviewBody (fields, extendedFields) {
     let table = [
       ['Field', 'Content']
     ]
@@ -297,7 +297,8 @@ class Staticman {
         configPath: this.configPath,
         fields,
         options: this.options,
-        parameters: this.parameters
+        parameters: this.parameters,
+        extendedFields
       }
 
       message += `\n\n<!--staticman_notification:${JSON.stringify(notificationsPayload)}-->`
@@ -502,6 +503,7 @@ class Staticman {
 
   processEntry (fields, options) {
     this.fields = Object.assign({}, fields)
+    this.extendedFields = null
     this.options = Object.assign({}, options)
 
     return this.getSiteConfig().then(config => {
@@ -522,6 +524,13 @@ class Staticman {
     }).then(transformedFields => {
       return this._applyInternalFields(transformedFields)
     }).then(extendedFields => {
+      /*
+       * Create a reference to the fields at this step of the process, as they contain the
+       * generated comment ID, which we would like to provide access to when generating the
+       * notification email.
+       */
+      this.extendedFields = extendedFields
+
       // Create file
       return this._createFile(extendedFields)
     }).then(data => {
@@ -547,10 +556,10 @@ class Staticman {
           data,
           newBranch,
           commitMessage,
-          this._generateReviewBody(fields)
+          this._generateReviewBody(fields, this.extendedFields)
         )
       } else if (subscriptions && options.parent) {
-        subscriptions.send(options.parent, fields, options, this.siteConfig)
+        subscriptions.send(options.parent, fields, this.extendedFields, options, this.siteConfig)
       }
 
       return this.git.writeFile(
@@ -572,14 +581,15 @@ class Staticman {
     })
   }
 
-  processMerge (fields, options) {
+  processMerge (fields, extendedFields, options) {
     this.fields = Object.assign({}, fields)
+    this.extendedFields = Object.assign({}, extendedFields)
     this.options = Object.assign({}, options)
 
     return this.getSiteConfig().then(config => {
       const subscriptions = this._initialiseSubscriptions()
 
-      return subscriptions.send(options.parent, fields, options, this.siteConfig)
+      return subscriptions.send(options.parent, fields, extendedFields, options, this.siteConfig)
     }).catch(err => {
       return Promise.reject(errorHandler('ERROR_PROCESSING_MERGE', {
         err,

--- a/lib/SubscriptionsManager.js
+++ b/lib/SubscriptionsManager.js
@@ -33,13 +33,72 @@ SubscriptionsManager.prototype._get = function (entryId) {
   })
 }
 
-SubscriptionsManager.prototype.send = function (entryId, fields, options, siteConfig) {
-  return this._get(entryId).then(list => {
-    if (list) {
-      const notifications = new Notification(this.mailAgent)
+/**
+ * Return true if the commenter (as identified by the given hash of their email address) is NOT
+ * the only subscriber in the identified mailing list, else false.
+ */
+SubscriptionsManager.prototype._calcIsCommenterNotOnlySubscriber = async function (listAddress, commenterEmailHashed) {
+  return new Promise((resolve, reject) => {
+    this.mailAgent.lists(listAddress).members().list((err, result) => {
+      /*
+       * By default, assume the posture that there are other interested parties that should be
+       * notified.
+       */
+      let commenterIsNotOnlySubscriber = true
 
-      return notifications.send(list, fields, options, {
-        siteName: siteConfig.get('name')
+      if (err) {
+        console.error(err)
+        console.error('Error determining if commenter is not the only subscriber. Assuming not.')
+      } else {
+        try {
+          /*
+           * If there is more than one subscriber in the list, return true. Ignore the subtlety
+           * that one or more people in the list might be "subscribed: false".
+           */
+          if (result.total_count === 1) {
+            const onlySubscriberEmail = result.items[0].address
+            /*
+             * The email addresses in the mailing list are maintained in the clear. Hash it so
+             * that we can compare it for equality.
+             */
+            const onlySubscriberEmailHashed = md5(onlySubscriberEmail)
+            if (onlySubscriberEmailHashed === commenterEmailHashed) {
+              commenterIsNotOnlySubscriber = false
+            }
+          }
+        } catch (error) {
+          console.error(error)
+          console.error('Error determining if commenter is not the only subscriber. Assuming not.')
+        }
+      }
+
+      return resolve(commenterIsNotOnlySubscriber)
+    })
+  })
+}
+
+SubscriptionsManager.prototype.send = function (entryId, fields, extendedFields, options, siteConfig) {
+  return this._get(entryId).then(listAddress => {
+    if (listAddress) {
+      /*
+       * Only send a notification email if the commenter is NOT the only subscriber found in the
+       * mailing list. This avoids the clumsy scenario where someone makes the first comment on a
+       * post (while choosing to subscribe to future comments) and then is sent a notification
+       * email for their own comment.
+       */
+      return this._calcIsCommenterNotOnlySubscriber(listAddress, fields.email).then((result) => {
+        if (result === true) {
+          const notifications = new Notification(this.mailAgent)
+
+          return notifications.send(listAddress, fields, extendedFields, options, {
+            siteName: siteConfig.get('name')
+          })
+        } else {
+          /*
+           * Don't send an email to notify the commenter of their own comment.
+           */
+          console.log('Commenter is the only subscriber. Suppressing notification.')
+        }
       })
     }
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
       "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w=="
     },
+    "a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
+    },
     "abab": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.2.tgz",
@@ -347,6 +352,11 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -6100,6 +6110,122 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "nunjucks": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.2.tgz",
+      "integrity": "sha512-KUi85OoF2NMygwODAy28Lh9qHmq5hO3rBlbkYoC8v377h4l8Pt5qFjILl0LWpMbOrZ18CzfVVUvIHUIrtED3sA==",
+      "requires": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "chokidar": "^3.3.0",
+        "commander": "^5.1.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "optional": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+          "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+          "optional": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+          "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.5.0"
+          }
+        },
+        "commander": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "optional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "optional": true
+        },
+        "readdirp": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+          "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+          "optional": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
     "nwsapi": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -6544,6 +6670,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "optional": true
     },
     "pify": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "moment": "^2.18.1",
     "node-rsa": "^0.4.2",
     "nodemon": "^1.19.4",
+    "nunjucks": "^3.2.2",
     "object-path": "^0.11.1",
     "request-promise": "^4.2.2",
     "sha1": "^1.1.1",

--- a/test/helpers/sampleData.js
+++ b/test/helpers/sampleData.js
@@ -175,7 +175,7 @@ Merge the pull request to accept it, or close it to send it away.
 | message | This is a test entry             |
 | date    | 1485597255                       |
 
-<!--staticman_notification:{"configPath":{"file":"staticman.yml","path":"comments"},"fields":{"name":"John","email":"017dab421e1e1cf6257bcadc0d289c62","url":"http://johndoe.com","address":"","message":"This is a test entry","date":1485597255},"options":{"slug":"2015-05-11-rethinking-the-commenting-system-for-my-jekyll-site","parent":"2015-05-11-rethinking-the-commenting-system-for-my-jekyll-site","origin":"https://eduardoboucas.com/blog/2015/05/11/rethinking-the-commenting-system-for-my-jekyll-site.html","subscribe":"email"},"parameters":{"username":"eduardoboucas","repository":"eduardoboucas.github.io","branch":"master","property":"comments"}}-->`
+<!--staticman_notification:{"configPath":{"file":"staticman.yml","path":"comments"},"fields":{"name":"John","email":"017dab421e1e1cf6257bcadc0d289c62","url":"http://johndoe.com","address":"","message":"This is a test entry","date":1485597255},"options":{"slug":"2015-05-11-rethinking-the-commenting-system-for-my-jekyll-site","parent":"2015-05-11-rethinking-the-commenting-system-for-my-jekyll-site","origin":"https://eduardoboucas.com/blog/2015/05/11/rethinking-the-commenting-system-for-my-jekyll-site.html","subscribe":"email"},"parameters":{"username":"eduardoboucas","repository":"eduardoboucas.github.io","branch":"master","property":"comments"},"extendedFields":{"_id":"bdb0c5d0-170b-11eb-94bf-652c3172a267","_parent":"2015-05-11-rethinking-the-commenting-system-for-my-jekyll-site","name":"John","email":"017dab421e1e1cf6257bcadc0d289c62","date":1485597255}}-->`
 
 module.exports.prBody2 = `Dear human,
 

--- a/test/unit/controllers/handlePR.test.js
+++ b/test/unit/controllers/handlePR.test.js
@@ -273,8 +273,6 @@ describe('HandlePR controller', () => {
       } catch (e) {
         expect(e).toBe(errorMessage)
         assertGetReviewCalls(service, mockGetReviewGitHub, mockGetReviewGitLab)
-        // expect(mockSetConfigPathFn.mock.calls.length).toBe(1)
-        // expect(mockProcessMergeFn.mock.calls.length).toBe(1)
         expect(mockSetConfigPathFn).toHaveBeenCalledTimes(1)
         expect(mockProcessMergeFn).toHaveBeenCalledTimes(1)
       }
@@ -327,6 +325,12 @@ describe('HandlePR controller', () => {
       }
       expect(mockSetConfigPathFn.mock.calls.length).toBe(1)
       expect(mockProcessMergeFn.mock.calls.length).toBe(1)
+
+      // Compare to values contained in sampleData.prBody1.
+      expect(mockProcessMergeFn.mock.calls[0][0].email).toBe('017dab421e1e1cf6257bcadc0d289c62')
+      expect(mockProcessMergeFn.mock.calls[0][1]._id).toBe('bdb0c5d0-170b-11eb-94bf-652c3172a267')
+      expect(mockProcessMergeFn.mock.calls[0][2].origin).toBe(
+        'https://eduardoboucas.com/blog/2015/05/11/rethinking-the-commenting-system-for-my-jekyll-site.html')
     })
   })
 })

--- a/test/unit/lib/Notification.test.js
+++ b/test/unit/lib/Notification.test.js
@@ -2,60 +2,152 @@ const config = require('./../../../config')
 const mockHelpers = require('./../../helpers')
 const Notification = require('./../../../lib/Notification')
 
-const mockSendFn = jest.fn()
-const mockMessagesFn = jest.fn(() => ({
-  send: mockSendFn
-}))
-const mockMailAgent = {
-  messages: mockMessagesFn
-}
+const recipient = 'john.doe@example.com'
+
+let mockMailAgent
+let mockSendFunc = jest.fn()
+
+let mockSubject
+let mockContent
+let mockSubjectError
+let mockContentError
+// Mock the readFile function within the native fs module, but leave every other function.
+jest.mock('fs', () => {
+  const fsOrig = require.requireActual('fs')
+  return {
+    ...fsOrig,
+    readFile: (path, options, callback) => {
+      // Only intercept requests for our subject and content templates.
+      if (path.endsWith('email-notification-subject.njk')) {
+        callback(mockSubjectError, mockSubject)
+      } else if (path.endsWith('email-notification-content.njk')) {
+        callback(mockContentError, mockContent)
+      } else {
+        return fsOrig.readFile(path, options, callback)
+      }
+    }
+  }
+})
 
 beforeEach(() => {
-  mockSendFn.mockClear()
-  mockMessagesFn.mockClear()
+  mockMailAgent = {
+    messages: jest.fn().mockImplementation(() => {
+      const result = {
+        send: mockSendFunc
+      }
+      return result
+    })
+  }
+
+  mockSubject = null
+  mockContent = null
+  mockSubjectError = null
+  mockContentError = null
+})
+
+afterEach(() => {
+  mockMailAgent.messages.mockClear()
+  mockSendFunc.mockClear()
 })
 
 describe('Notification interface', () => {
-  const mockData = {
+  let mockData = {
     data: {
-      siteName: 'Eduardo\'s blog'
+      siteName: 'Test blog'
     },
     fields: {
       name: 'Eduardo Bouças',
       email: 'mail@eduardoboucas.com'
     },
+    extendedFields: {
+      _id: '70c33c00-17b3-11eb-b910-2f4fc1bf5873'
+    },
     options: {
-      origin: 'https://eduardoboucas.com'
+      origin: 'https://eduardoboucas.com/an-awesome-post-about-staticman', 
+      parent: 'an-awesome-post-about-staticman'
     } 
   }
 
-  test('builds an email message from the template, replacing the placeholders with the data provided', () => {
-    const notification = new Notification(mockMailAgent)
-    const message = notification._buildMessage(mockData.fields, mockData.options, mockData.data)
+  describe('send', () => {
+    test('sends notification email with customized subject and content', async () => {
+      const notification = new Notification(mockMailAgent)
+      
+      mockSendFunc.mockImplementation( (payload, callback) => callback(null, 'success') )
 
-    expect(message.includes(mockData.data.siteName)).toBe(true)
-    expect(message.includes(mockData.options.origin)).toBe(true)
-  })
+      mockSubject = 'FYI - {{ options.origin }} has a new comment'
+      mockContent = 'New comment by {{ fields.name }} on {{ data.siteName }} here - {{ options.origin }}#comment-{{ extendedFields._id }}.'
 
-  test('sends an email through the mail agent', () => {
-    const notification = new Notification(mockMailAgent)
-    const message = notification._buildMessage(mockData.fields, mockData.options, mockData.data)
-    const recipient = 'john.doe@foobar.com'
-    
-    notification.send(
-      recipient,
-      mockData.fields,
-      mockData.options,
-      mockData.data
-    )
+      expect.hasAssertions()
+      await notification.send(recipient, mockData.fields, mockData.extendedFields, mockData.options, mockData.data).then(response => {
+        expect(mockSendFunc).toHaveBeenCalledTimes(1)
+        expect(mockSendFunc.mock.calls[0][0].from.includes(config.get('email.fromAddress'))).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].to).toBe(recipient)
+        expect(mockSendFunc.mock.calls[0][0].subject).toBe('FYI - ' + mockData.options.origin + ' has a new comment')
+        expect(mockSendFunc.mock.calls[0][0].html).toBe(
+          'New comment by ' + mockData.fields.name + ' on ' + mockData.data.siteName + ' here - ' + 
+          mockData.options.origin + '#comment-' + mockData.extendedFields._id + '.')
+        expect(mockSendFunc.mock.calls[0][0]['h:Reply-To']).toBe(mockSendFunc.mock.calls[0][0].from)
+      })
+    })
 
-    expect(mockSendFn.mock.calls.length).toBe(1)
-    expect(mockSendFn.mock.calls[0][0]).toEqual({
-      from: `${config.get('email.fromName')} <${config.get('email.fromAddress')}>`,
-      'h:Reply-To': `${config.get('email.fromName')} <${config.get('email.fromAddress')}>`,
-      to: recipient,
-      subject: `New reply on "${mockData.data.siteName}"`,
-      html: message
+    test('sends notification email with default subject and content', async () => {
+      const notification = new Notification(mockMailAgent)
+      
+      mockSendFunc.mockImplementation( (payload, callback) => callback(null, 'success') )
+
+      // Force errors when trying to read the subject and content templates.
+      mockSubjectError = 'subject readFile error'
+      mockContentError = 'content readFile error'
+
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect.hasAssertions()
+      await notification.send(recipient, mockData.fields, mockData.extendedFields, mockData.options, mockData.data).then(response => {
+        expect(mockSendFunc).toHaveBeenCalledTimes(1)
+        expect(mockSendFunc.mock.calls[0][0].from.includes(config.get('email.fromAddress'))).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].to).toBe(recipient)
+        // Expect that the default email subject will be used.
+        expect(mockSendFunc.mock.calls[0][0].subject).toBe('There is a new comment at ' + mockData.data.siteName)
+        // Expect that the default email content will be used.
+        expect(mockSendFunc.mock.calls[0][0].html.includes(
+          'There is a new comment at <a href="' + mockData.options.origin + '">' + mockData.options.origin + '</a>.')).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].html.includes(
+          'If you prefer, you may <a href="%mailing_list_unsubscribe_url%">unsubscribe</a> from future emails.')).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0]['h:Reply-To']).toBe(mockSendFunc.mock.calls[0][0].from)
+
+        // Restore console.error
+        consoleSpy.mockRestore();
+      })
+    })
+
+    test('send error handled', async () => {
+      const notification = new Notification(mockMailAgent)
+      
+      // Mock that the message send errors.
+      mockSendFunc.mockImplementation( (payload, callback) => callback(
+        {statusCode: 500, message: 'message send failure'}, null) )
+
+      mockSubject = 'Test subject'
+      mockContent = 'Test content'
+
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect.hasAssertions()
+      await notification.send(recipient, mockData.fields, mockData.extendedFields, mockData.options, mockData.data).catch(error => {
+        expect(error.message).toBe('message send failure')
+
+        expect(mockSendFunc).toHaveBeenCalledTimes(1)
+        expect(mockSendFunc.mock.calls[0][0].from.includes(config.get('email.fromAddress'))).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].to).toBe(recipient)
+        expect(mockSendFunc.mock.calls[0][0].subject).toBe(mockSubject)
+        expect(mockSendFunc.mock.calls[0][0].html).toBe(mockContent)
+        expect(mockSendFunc.mock.calls[0][0]['h:Reply-To']).toBe(mockSendFunc.mock.calls[0][0].from)
+
+        // Restore console.error
+        consoleSpy.mockRestore();
+      })
     })
   })
 })

--- a/test/unit/lib/SubscriptionsManager.test.js
+++ b/test/unit/lib/SubscriptionsManager.test.js
@@ -1,4 +1,6 @@
+const md5 = require('md5')
 
+const mockHelpers = require('./../../helpers')
 
 const SubscriptionsManager = require('./../../../lib/SubscriptionsManager')
 
@@ -11,31 +13,46 @@ const dataStore = null
 let mockListsInfoFunc = jest.fn()
 let mockListsCreateFunc = jest.fn()
 let mockListsMembersCreateFunc = jest.fn()
+let mockListsMembersListFunc = jest.fn()
+let mockNotificationSendFunc = jest.fn()
+
+jest.mock('./../../../lib/Notification', () => {
+  return jest.fn(() => ({
+    send: mockNotificationSendFunc
+  }))
+})
+
 let mockMailAgent
 
 let options
+let fields
+let extendedFields
+let siteConfig
+let listMembers
 const emailAddr = 'foo@example.com'
 
 beforeEach(() => {
   mockMailAgent = {
-	lists: jest.fn().mockImplementation(listaddr => {
-	  const result = {
-		info: mockListsInfoFunc,
-		create: mockListsCreateFunc,
-		members: jest.fn().mockImplementation(() => {
-		  const result = {
-			create: mockListsMembersCreateFunc
-		  }
-		  return result
-		})
-	  }
-	  return result
-	}), 
-	domain: 'example.com'
+  	lists: jest.fn().mockImplementation(listaddr => {
+  	  const result = {
+    		info: mockListsInfoFunc,
+    		create: mockListsCreateFunc,
+    		members: jest.fn().mockImplementation(() => {
+    		  const result = {
+    			  create: mockListsMembersCreateFunc,
+            list: mockListsMembersListFunc
+    		  }
+    		  return result
+    		})
+  	  }
+  	  return result
+  	}), 
+  	domain: 'example.com'
   }
 
   options = {
-	parent: 'an-awesome-post-about-staticman'
+	  parent: 'an-awesome-post-about-staticman',
+    origin: 'http://blog.example.com'
   }
 })
 
@@ -44,130 +61,316 @@ afterEach(() => {
   mockListsInfoFunc.mockClear()
   mockListsCreateFunc.mockClear()
   mockListsMembersCreateFunc.mockClear()
+  mockListsMembersListFunc.mockClear()
+  mockNotificationSendFunc.mockClear()
 })
 
 describe('SubscriptionsManager', () => {
-  test('creates mailing list if it does not exist and adds subscriber', async () => {
-    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+  describe('set', () => {
+    test('creates mailing list if it does not exist and adds subscriber', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
 
-    // Mock that the list does not exist.
-    mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
-    mockListsCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success') )
-    mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
+      // Mock that the list does not exist.
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
+      mockListsCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success') )
+      mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
 
-    expect.hasAssertions()
-    await subscriptionsMgr.set(options, emailAddr).then(response => {
-      expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
-      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
-      expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
-      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
-      expect(mockMailAgent.lists.mock.calls[0][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
-      expect(mockListsCreateFunc.mock.calls[0][0]['address']).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
-      expect(mockListsCreateFunc.mock.calls[0][0]['access_level']).toBe('readonly')
-      expect(mockListsCreateFunc.mock.calls[0][0]['reply_preference']).toBe('sender')
-      expect(mockListsMembersCreateFunc.mock.calls[0][0]).toEqual( { address: emailAddr } )
+      expect.hasAssertions()
+      await subscriptionsMgr.set(options, emailAddr).then(response => {
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
+        expect(mockMailAgent.lists.mock.calls[0][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+        expect(mockListsCreateFunc.mock.calls[0][0]['address']).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+        expect(mockListsCreateFunc.mock.calls[0][0]['access_level']).toBe('readonly')
+        expect(mockListsCreateFunc.mock.calls[0][0]['reply_preference']).toBe('sender')
+        expect(mockListsMembersCreateFunc.mock.calls[0][0]).toEqual( { address: emailAddr } )
+      })
+    })
+
+    test('creates mailing list (with name and description) if it does not exist and adds subscriber', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+      // Mock that the list does not exist.
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
+      mockListsCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success') )
+      mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
+
+      // Set the optional parent name.
+      options.parentName = 'Post an-awesome-post-about-staticman'
+
+      expect.hasAssertions()
+      await subscriptionsMgr.set(options, emailAddr).then(response => {
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
+        expect(mockMailAgent.lists.mock.calls[0][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+        expect(mockListsCreateFunc.mock.calls[0][0]['address']).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+        expect(mockListsCreateFunc.mock.calls[0][0]['access_level']).toBe('readonly')
+        expect(mockListsCreateFunc.mock.calls[0][0]['reply_preference']).toBe('sender')
+        // Assert that "name" and "description" are passed when parent name is supplied.
+        expect(mockListsCreateFunc.mock.calls[0][0]['name']).toBe(options.parentName)
+        expect(mockListsCreateFunc.mock.calls[0][0]['description']).toBe(
+        	'Subscribers to: ' + options.parentName + ' (' + params.username + '/' + params.repository + ')')
+        expect(mockListsMembersCreateFunc.mock.calls[0][0]).toEqual( { address: emailAddr } )
+      })
+    })
+
+    test('does not create mailing list if it already exists and adds subscriber', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+      // Mock that the list exists.
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, {list: {}}) )
+      mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
+
+      expect.hasAssertions()
+      await subscriptionsMgr.set(options, emailAddr).then(response => {
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        // Assert that list not created.
+        expect(mockListsCreateFunc).toHaveBeenCalledTimes(0)
+        expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
+        expect(mockMailAgent.lists.mock.calls[0][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+        expect(mockListsMembersCreateFunc.mock.calls[0][0]).toEqual( { address: emailAddr } )
+      })
+    })
+
+    test('list lookup error handled', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+      // Mock that the list lookup errors.
+      mockListsInfoFunc.mockImplementation( (callback) => 
+        callback({statusCode: 500, message: 'list lookup failure'}, null) )
+
+      expect.hasAssertions()
+      await subscriptionsMgr.set(options, emailAddr).catch(error => {
+        expect(error.message).toBe('list lookup failure')
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(1)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsCreateFunc).toHaveBeenCalledTimes(0)
+        expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(0)
+      })
+    })
+
+    test('list create error handled', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
+      // Mock that the list create errors.
+      mockListsCreateFunc.mockImplementation( (createData, callback) => 
+        callback({statusCode: 500, message: 'list create failure'}, null) )
+
+      expect.hasAssertions()
+      await subscriptionsMgr.set(options, emailAddr).catch(error => {
+        expect(error.message).toBe('list create failure')
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(0)
+      })
+    })
+
+    test('list member create error handled', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
+      mockListsCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success') )
+      // Mock that the list member create errors.
+      mockListsMembersCreateFunc.mockImplementation( (createData, callback) => 
+        callback({statusCode: 500, message: 'member create failure'}, null) )
+
+      expect.hasAssertions()
+      await subscriptionsMgr.set(options, emailAddr).catch(error => {
+        expect(error.message).toBe('member create failure')
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
+      })
     })
   })
 
-  test('creates mailing list (with name and description) if it does not exist and adds subscriber', async () => {
-    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+  describe('send', () => {
 
-    // Mock that the list does not exist.
-    mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
-    mockListsCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success') )
-    mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
+    beforeEach(() => {
+      listMembers = {
+        items: [
+          {
+            address: 'bob@example.com',
+            name: '',
+            subscribed: true,
+            vars: {}
+          }, {
+            address: 'jim@example.com',
+            name: '',
+            subscribed: true,
+            vars: {}
+          }
+        ],
+        total_count: 2
+      }
 
-    // Set the optional parent name.
-    options.parentName = 'Post an-awesome-post-about-staticman'
+      fields = mockHelpers.getFields()
+      fields.email = md5('bob@example.com')
 
-    expect.hasAssertions()
-    await subscriptionsMgr.set(options, emailAddr).then(response => {
-      expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
-      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
-      expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
-      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
-      expect(mockMailAgent.lists.mock.calls[0][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
-      expect(mockListsCreateFunc.mock.calls[0][0]['address']).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
-      expect(mockListsCreateFunc.mock.calls[0][0]['access_level']).toBe('readonly')
-      expect(mockListsCreateFunc.mock.calls[0][0]['reply_preference']).toBe('sender')
-      // Assert that "name" and "description" are passed when parent name is supplied.
-      expect(mockListsCreateFunc.mock.calls[0][0]['name']).toBe(options.parentName)
-      expect(mockListsCreateFunc.mock.calls[0][0]['description']).toBe(
-      	'Subscribers to: ' + options.parentName + ' (' + params.username + '/' + params.repository + ')')
-      expect(mockListsMembersCreateFunc.mock.calls[0][0]).toEqual( { address: emailAddr } )
+      extendedFields = {
+        _id: '70c33c00-17b3-11eb-b910-2f4fc1bf5873'
+      }
+      extendedFields = Object.assign({}, fields)
+
+      siteConfig = mockHelpers.getConfig()
     })
-  })
 
-  test('does not create mailing list if it already exists and adds subscriber', async () => {
-    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+    test('sends notification email to mailing list', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
 
-    // Mock that the list exists.
-    mockListsInfoFunc.mockImplementation( (callback) => callback(null, {list: {}}) )
-    mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
+      // Mock that the list exists.
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, {list: {}}) )
+      mockListsMembersListFunc.mockImplementation( (callback) => callback(null, listMembers) )
+      mockNotificationSendFunc.mockImplementation(() => Promise.resolve('success'))
 
-    expect.hasAssertions()
-    await subscriptionsMgr.set(options, emailAddr).then(response => {
-      expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
-      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
-      // Assert that list not created.
-      expect(mockListsCreateFunc).toHaveBeenCalledTimes(0)
-      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
-      expect(mockMailAgent.lists.mock.calls[0][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
-      expect(mockListsMembersCreateFunc.mock.calls[0][0]).toEqual( { address: emailAddr } )
+      expect.hasAssertions()
+      await subscriptionsMgr.send(options.parent, fields, extendedFields, options, siteConfig).then(response => {
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersListFunc).toHaveBeenCalledTimes(1)
+        expect(mockNotificationSendFunc).toHaveBeenCalledTimes(1)
+        expect(mockMailAgent.lists.mock.calls[0][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+        expect(mockMailAgent.lists.mock.calls[1][0]).toBe('26b053c67a70a1127b71783c3d39d355@example.com')
+        // Verify important values instead of the entire objects. More robust.
+        expect(mockNotificationSendFunc.mock.calls[0][1]['email']).toBe(fields.email)
+        expect(mockNotificationSendFunc.mock.calls[0][2]['_id']).toBe(extendedFields._id)
+        expect(mockNotificationSendFunc.mock.calls[0][3]['origin']).toBe(options.origin)
+      })
     })
-  })
 
-  test('list lookup error handled', async () => {
-    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+    test('sends no notification email if mailing list does not exist', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
 
-    // Mock that the list lookup errors.
-    mockListsInfoFunc.mockImplementation( (callback) => 
-      callback({statusCode: 500, message: 'list lookup failure'}, null) )
+      // Mock that the list does not exist.
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
 
-    expect.hasAssertions()
-    await subscriptionsMgr.set(options, emailAddr).catch(error => {
-      expect(error.message).toBe('list lookup failure')
-      expect(mockMailAgent.lists).toHaveBeenCalledTimes(1)
-      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
-      expect(mockListsCreateFunc).toHaveBeenCalledTimes(0)
-      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(0)
+      expect.hasAssertions()
+      await subscriptionsMgr.send(options.parent, fields, extendedFields, options, siteConfig).then(response => {
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(1)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersListFunc).toHaveBeenCalledTimes(0)
+        expect(mockNotificationSendFunc).toHaveBeenCalledTimes(0)
+      })
     })
-  })
 
-  test('list create error handled', async () => {
-    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+    test('sends no notification email if commenter is the only subscriber', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
 
-    mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
-    // Mock that the list create errors.
-    mockListsCreateFunc.mockImplementation( (createData, callback) => 
-      callback({statusCode: 500, message: 'list create failure'}, null) )
+      // Remove the list member who is NOT the commenter.
+      listMembers.items.pop()
+      listMembers.total_count = listMembers.items.length
 
-    expect.hasAssertions()
-    await subscriptionsMgr.set(options, emailAddr).catch(error => {
-      expect(error.message).toBe('list create failure')
-      expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
-      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
-      expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
-      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(0)
+      // Mock that the list exists.
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, {list: {}}) )
+      mockListsMembersListFunc.mockImplementation( (callback) => callback(null, listMembers) )
+      mockNotificationSendFunc.mockImplementation(() => Promise.resolve('success'))
+
+      expect.hasAssertions()
+      await subscriptionsMgr.send(options.parent, fields, extendedFields, options, siteConfig).then(response => {
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersListFunc).toHaveBeenCalledTimes(1)
+        expect(mockNotificationSendFunc).toHaveBeenCalledTimes(0)
+      })
     })
-  })
 
-  test('list member create error handled', async () => {
-    const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+    test('sends notification email if commenter is not the only subscriber', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
 
-    mockListsInfoFunc.mockImplementation( (callback) => callback(null, null) )
-    mockListsCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success') )
-    // Mock that the list member create errors.
-    mockListsMembersCreateFunc.mockImplementation( (createData, callback) => 
-      callback({statusCode: 500, message: 'member create failure'}, null) )
+      // Remove the list member who IS the commenter.
+      listMembers.items.shift()
+      listMembers.total_count = listMembers.items.length
 
-    expect.hasAssertions()
-    await subscriptionsMgr.set(options, emailAddr).catch(error => {
-      expect(error.message).toBe('member create failure')
-      expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
-      expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
-      expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
-      expect(mockListsMembersCreateFunc).toHaveBeenCalledTimes(1)
+      // Mock that the list exists.
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, {list: {}}) )
+      mockListsMembersListFunc.mockImplementation( (callback) => callback(null, listMembers) )
+      mockNotificationSendFunc.mockImplementation(() => Promise.resolve('success'))
+
+      expect.hasAssertions()
+      await subscriptionsMgr.send(options.parent, fields, extendedFields, options, siteConfig).then(response => {
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersListFunc).toHaveBeenCalledTimes(1)
+        expect(mockNotificationSendFunc).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    test('list lookup error handled', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+      // Mock that the list lookup errors.
+      mockListsInfoFunc.mockImplementation( (callback) => 
+        callback({statusCode: 500, message: 'list lookup failure'}, null) )
+
+      expect.hasAssertions()
+      await subscriptionsMgr.send(options.parent, fields, extendedFields, options, siteConfig).catch(error => {
+        expect(error.message).toBe('list lookup failure')
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(1)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersListFunc).toHaveBeenCalledTimes(0)
+        expect(mockNotificationSendFunc).toHaveBeenCalledTimes(0)
+      })
+    })
+
+    test('member list lookup error handled', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+      // Mock that the list exists.
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, {list: {}}) )
+      // Mock that the member list lookup errors.
+      mockListsMembersListFunc.mockImplementation( (callback) => 
+        callback({statusCode: 500, message: 'member list lookup failure'}, null) )
+      mockNotificationSendFunc.mockImplementation(() => Promise.resolve('success'))
+
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect.hasAssertions()
+      await subscriptionsMgr.send(options.parent, fields, extendedFields, options, siteConfig).then(response => {
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersListFunc).toHaveBeenCalledTimes(1)
+        // If the member list lookup fails, assume the commenter is not the only subscriber and send.
+        expect(mockNotificationSendFunc).toHaveBeenCalledTimes(1)
+
+        // Restore console.error
+        consoleSpy.mockRestore();
+      })
+    })
+
+    test('member list processing error handled', async () => {
+      const subscriptionsMgr = new SubscriptionsManager(params, dataStore, mockMailAgent)
+
+      // Force a code execution error.
+      listMembers = null
+
+      // Mock that the list exists.
+      mockListsInfoFunc.mockImplementation( (callback) => callback(null, {list: {}}) )
+      mockListsMembersListFunc.mockImplementation( (callback) => callback(null, listMembers) )
+      mockNotificationSendFunc.mockImplementation(() => Promise.resolve('success'))
+
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      expect.hasAssertions()
+      await subscriptionsMgr.send(options.parent, fields, extendedFields, options, siteConfig).then(response => {
+        expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
+        expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
+        expect(mockListsMembersListFunc).toHaveBeenCalledTimes(1)
+        // If the member list processing fails, assume the commenter is not the only subscriber and send.
+        expect(mockNotificationSendFunc).toHaveBeenCalledTimes(1)
+
+        // Restore console.error
+        consoleSpy.mockRestore();
+      })
     })
   })
 })


### PR DESCRIPTION
This addresses issue https://github.com/eduardoboucas/staticman/issues/173 - "Override text sent in email subscription".

I modified the code to source the notification email subject from `email-notification-subject.njk` and notification email content from `email-notification-content.njk`. Both are located at the root of the codebase and populated with the existing subject/content. If an error is raised when reading either, a stripped-down default is used.

[Nunjucks](https://mozilla.github.io/nunjucks/) is used as the templating language, as it includes a large amount of built-in functionality.

An `extendedFields` element is now included in the `staticman_notification` HTML comment that is embedded in the merge request review body (when moderation is enabled). This is in addition to `fields`, `options`, and `parameters`. This is necessary in order to make the Staticman-generated comment ID available when generating notification emails (so that they may contain a link directly to the triggering comment on the page).

A notification email is now sent only if the commenter is **not** the only subscriber found in the mailing list. This avoids the clumsy scenario where someone makes the first comment on a post (while choosing to subscribe to future comments) and then is sent a notification email for their own comment.