### PR TITLE
Include "parent" in mailing list description

### DIFF
--- a/lib/SubscriptionsManager.js
+++ b/lib/SubscriptionsManager.js
@@ -139,7 +139,7 @@ SubscriptionsManager.prototype.set = function (options, email) {
              */
             payload.name = entryName
             /*
-             * For the description, include the elements that are used to generate the list 
+             * For the description, include the elements that are used to generate the list
              * address hash value.
              */
             payload.description = 'Subscribers to ' + entryId +

--- a/lib/SubscriptionsManager.js
+++ b/lib/SubscriptionsManager.js
@@ -138,7 +138,11 @@ SubscriptionsManager.prototype.set = function (options, email) {
              * hash value.
              */
             payload.name = entryName
-            payload.description = 'Subscribers to: ' + entryName +
+            /*
+             * For the description, include the elements that are used to generate the list 
+             * address hash value.
+             */
+            payload.description = 'Subscribers to ' + entryId +
               ' (' + this.parameters.username + '/' + this.parameters.repository + ')'
           }
 

--- a/test/unit/lib/SubscriptionsManager.test.js
+++ b/test/unit/lib/SubscriptionsManager.test.js
@@ -113,7 +113,7 @@ describe('SubscriptionsManager', () => {
         // Assert that "name" and "description" are passed when parent name is supplied.
         expect(mockListsCreateFunc.mock.calls[0][0]['name']).toBe(options.parentName)
         expect(mockListsCreateFunc.mock.calls[0][0]['description']).toBe(
-        	'Subscribers to: ' + options.parentName + ' (' + params.username + '/' + params.repository + ')')
+        	'Subscribers to ' + options.parent + ' (' + params.username + '/' + params.repository + ')')
         expect(mockListsMembersCreateFunc.mock.calls[0][0]).toEqual( { address: emailAddr } )
       })
     })


### PR DESCRIPTION
When creating the mailing list, set the description to include `parent`, not `parentName`. By doing this, we expose/communicate all of the elements used to generate the list address hash value.