### PR TITLE
Add support for double opt-in and GDPR-compliant email notifications

### DIFF
--- a/config.js
+++ b/config.js
@@ -133,6 +133,13 @@ const schema = {
     default: null,
     env: 'RSA_PRIVATE_KEY'
   },
+  cryptoPepper: {
+    doc: 'Shared (app-wide) secret that can be used to verify the authenticity of hashed/encrypted strings that we create. Should be long to defend against brute force attacks.',
+    docExample: 'bcacf76bef428bf6115abfaa664e73481657e5068b9534227dca6ec96c6931b113105be81cb177b4e22d42fbc32d04ea5a8133e97296de7852328',
+    format: String,
+    default: null,
+    env: 'CRYPTO_PEPPER'
+  },
   logging: {
     slackWebhook: {
       doc: 'Slack webhook URL to pipe log output to',

--- a/controllers/confirmSubscription.js
+++ b/controllers/confirmSubscription.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const path = require('path')
+
+const config = require(path.join(__dirname, '/../config'))
 const RSA = require('../lib/RSA')
 const Staticman = require('../lib/Staticman')
 const sendResponse = require('./sendResponse')
@@ -17,8 +20,21 @@ module.exports = async (req, res, next) => {
 
   let confirmData = null
   try {
+    // If the encrypted string is spoofed, the JSON parse will return null.
     const decryptedDataStr = RSA.decrypt(encryptedDataStr)
     confirmData = JSON.parse(decryptedDataStr)
+
+    /*
+     * Verify the pepper we inserted in the encrypted payload when creating the confirmation email.
+     * More info - https://en.wikipedia.org/wiki/Pepper_(cryptography)
+     * We do this because the "encrypt" endpoint is currently exposed for anyone to hit. As such,
+     * an attacker could easily create their own valid encrypted strings and subscribe whoever they
+     * want. They'd be able to see the expected structure of the payload data simply by looking at
+     * the source code.
+     */
+    if (confirmData === null || confirmData.pepper !== config.get('cryptoPepper')) {
+      throw new Error('Authenticity check failed.')
+    }
 
     const staticman = await new Staticman(req.params)
     staticman.setConfigPath()
@@ -36,9 +52,12 @@ module.exports = async (req, res, next) => {
     })
   } catch (error) {
     console.error(error.stack || error)
-    sendResponse(res, {
-      err: error,
-      redirectError: confirmData.subscribeConfirmRedirectError
-    })
+    let data = {
+      err: error
+    }
+    if (confirmData !== null) {
+      data.redirectError = confirmData.subscribeConfirmRedirectError
+    }
+    sendResponse(res, data)
   }
 }

--- a/controllers/confirmSubscription.js
+++ b/controllers/confirmSubscription.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const RSA = require('../lib/RSA')
+const Staticman = require('../lib/Staticman')
+const sendResponse = require('./sendResponse')
+
+/**
+ * Express handler for requests to confirm that a user wants to subscribe to notification emails
+ * sent whenever new comments are added (to a post, parent comment, etc.).
+ */
+module.exports = async (req, res, next) => {
+  /*
+   * All of the data needed to process a subscription confirmation (aside from values contained in
+   * the URL path such as repo, branch, etc.) will be passed in the "data" querystring value.
+   */
+  const encryptedDataStr = req.query.data
+
+  let confirmData = null
+  try {
+    const decryptedDataStr = RSA.decrypt(encryptedDataStr)
+    confirmData = JSON.parse(decryptedDataStr)
+
+    const staticman = await new Staticman(req.params)
+    staticman.setConfigPath()
+
+    return staticman.createSubscription(confirmData).then(data => {
+      sendResponse(res, {
+        redirect: confirmData.subscribeConfirmRedirect
+      })
+    }).catch(error => {
+      console.error(error.stack || error)
+      sendResponse(res, {
+        err: error,
+        redirectError: confirmData.subscribeConfirmRedirectError
+      })
+    })
+  } catch (error) {
+    console.error(error.stack || error)
+    sendResponse(res, {
+      err: error,
+      redirectError: confirmData.subscribeConfirmRedirectError
+    })
+  }
+}

--- a/controllers/process.js
+++ b/controllers/process.js
@@ -48,20 +48,6 @@ function checkRecaptcha (staticman, req) {
   })
 }
 
-function createConfigObject (apiVersion, property) {
-  let remoteConfig = {}
-
-  if (apiVersion === '1') {
-    remoteConfig.file = '_config.yml'
-    remoteConfig.path = 'staticman'
-  } else {
-    remoteConfig.file = 'staticman.yml'
-    remoteConfig.path = property || ''
-  }
-
-  return remoteConfig
-}
-
 function process (staticman, req, res) {
   const ua = config.get('analytics.uaTrackingId')
     ? universalAnalytics(config.get('analytics.uaTrackingId'))
@@ -95,5 +81,4 @@ module.exports = async (req, res, next) => {
 }
 
 module.exports.checkRecaptcha = checkRecaptcha
-module.exports.createConfigObject = createConfigObject
 module.exports.process = process

--- a/controllers/sendResponse.js
+++ b/controllers/sendResponse.js
@@ -1,0 +1,67 @@
+'use strict'
+
+const { URL, URLSearchParams } = require('url')
+const errorHandler = require('../lib/ErrorHandler')
+
+/**
+ * Module for "encoding" the result of a request into the Express response. It is possible for
+ * the response (whether success or failure) to be communicated back via a redirect to a supplied
+ * URL or in a direct response (most likely to an AJAX request).
+ */
+module.exports = (res, data) => {
+  const error = data && data.err
+  const statusCode = error ? 500 : 200
+
+  /*
+   * If there are any secondary errors that were raised during processing, communicate them
+   * back in the response. These are errors that do not invalidate the result as being a
+   * success, but they qualify as warnings that should possibly be displayed to the user.
+   */
+  const secondaryErrors = data.secondaryErrors
+
+  if (!error && data.redirect) {
+    const redirectUrl = new URL(data.redirect)
+
+    if (secondaryErrors) {
+      redirectUrl.search = new URLSearchParams(secondaryErrors)
+    }
+
+    return res.redirect(redirectUrl.toString())
+  }
+
+  if (error && data.redirectError) {
+    return res.redirect(data.redirectError)
+  }
+
+  let payload = {
+    success: !error
+  }
+
+  if (error && error._smErrorCode) {
+    const errorCode = errorHandler.getInstance().getErrorCode(error._smErrorCode)
+    const errorMessage = errorHandler.getInstance().getMessage(error._smErrorCode)
+
+    if (errorMessage) {
+      payload.message = errorMessage
+    }
+
+    if (error.data) {
+      payload.data = error.data
+    }
+
+    if (error) {
+      payload.rawError = error
+    }
+
+    payload.errorCode = errorCode
+  } else if (error) {
+    payload.rawError = data.err.toString()
+  } else {
+    payload.fields = data.fields
+    if (secondaryErrors) {
+      payload.secondaryErrors = secondaryErrors
+    }
+  }
+
+  res.status(statusCode).send(payload)
+}

--- a/email-confirmation-content.njk
+++ b/email-confirmation-content.njk
@@ -1,0 +1,5 @@
+{#
+    This template may be modified to customize the content of emails sent to confirm that 
+    commenters want to subscribe to comments. Uses the Nunjucks templating language. More info -
+    https://mozilla.github.io/nunjucks/
+#}

--- a/email-confirmation-subject.njk
+++ b/email-confirmation-subject.njk
@@ -1,0 +1,5 @@
+{#
+    This template may be modified to customize the content of the subject line used in emails sent 
+    to confirm that commenters want to subscribe to comments. Uses the Nunjucks templating language.
+    More info - https://mozilla.github.io/nunjucks/
+#}

--- a/lib/Confirmation.js
+++ b/lib/Confirmation.js
@@ -1,0 +1,239 @@
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const util = require('util')
+const config = require(path.join(__dirname, '/../config'))
+const RSA = require(path.join(__dirname, '/../lib/RSA'))
+const nunjucks = require('nunjucks')
+
+const readFileAsync = util.promisify(fs.readFile)
+
+const confirmTextDelimiterStart = '<!--confirmTextStart-->'
+const confirmTextDelimiterEnd = '<!--confirmTextEnd-->'
+
+const Confirmation = function (mailAgent) {
+  this.mailAgent = mailAgent
+}
+
+/**
+ * Send an email to the given recipient to confirm that they want to subscribe to comments.
+ * @param toEmailAddress {String} - The email address of the potential subscriber.
+ * @param fields {Object} - Simple mapping of "fields" key-value pairs gathered when the comment
+ *  was submitted, moderately processed. Mostly contains data provided by the commenter,
+ *  including the comment, comment author, and commenter email address (hashed). However, any
+ *  Staticman-generated comment date ends up in here, too.
+ * @param extendedFields {Object} - Simple mapping of key-value pairs generated when the comment
+ *  was submitted, fully processed. In addition to the data found in the "fields" parameter, also
+ *  includes the Staticman-generated comment ID.
+ * @param options {Object} - Simple mapping of "options" key-value pairs gathered when the comment
+ *  was submitted. Mostly metadata, including the origin site, ID of the comment's parent, etc.
+ * @param data {Object} - Simple mapping of key-value pairs containing any other pertinent data,
+ *  such as configuration parameters.
+ * return {Promise} - resolvable to the result of attempting to send the email
+ */
+Confirmation.prototype.send = function (toEmailAddress, fields, extendedFields, options, data) {
+  return new Promise(async (resolve, reject) => {
+    let payload = {
+      from: `${config.get('email.fromName')} <${config.get('email.fromAddress')}>`,
+      to: toEmailAddress
+    }
+
+    payload.subject = await _buildSubject(
+      toEmailAddress, fields, extendedFields, options, data)
+    payload.html = await _buildMessage(
+      toEmailAddress, fields, extendedFields, options, data, payload.subject)
+
+    payload['h:Reply-To'] = payload.from
+
+    this.mailAgent.messages().send(payload, (err, res) => {
+      if (err) {
+        console.error(err)
+        return reject(err)
+      }
+
+      return resolve(res)
+    })
+  })
+}
+
+/**
+ * Return an object containing single opt-in ("consent") audit fields using the given "raw"
+ * options metadata. Intentionally implemented as a "static" function so it can be accessed
+ * without instantiating a Confirmation.
+ * @param options {Object} - Simple mapping of "options" key-value pairs (assumed to have been
+ *  gathered when a comment was submitted. Assumed to contain the consent URL
+ *  (subscribeConsentUrl), context (subscribeConsentContext), and text (subscribeConsentText).
+ *  May also contain a consent date (subscribeConsentDate) if obtained earlier.
+ *  If subscribeConsentUrl not supplied, origin will be used. If subscribeConsentContext not
+ *  supplied, parentName will be used.
+ * return {Object}
+ */
+Confirmation.buildConsentData = function (options) {
+  return _buildConsentData(options)
+}
+
+module.exports = Confirmation
+
+const _buildSubject = async function (toEmailAddress, fields, extendedFields, options, data) {
+  let subject = null
+  try {
+    const templateContent = await _loadEmailTemplate('subject')
+    subject = nunjucks.renderString(templateContent, {
+      fields: fields,
+      extendedFields: extendedFields,
+      options: options,
+      data: data
+    })
+
+    if (subject.trim() === '') {
+      throw new Error(`The rendered confirmation email subject is empty.`)
+    }
+  } catch (error) {
+    console.error(error)
+    console.error(`Using default subject for confirmation email.`)
+    subject = `Please confirm your subscription to ${data.siteName}`
+  }
+  return subject
+}
+
+const _buildMessage = async function (toEmailAddress, fields, extendedFields, options, data, emailSubject) {
+  let emailContent = null
+  try {
+    const templateContent = await _loadEmailTemplate('content')
+    const confirmLink = _buildConfirmationLink(templateContent, toEmailAddress, fields, options, emailSubject)
+
+    emailContent = nunjucks.renderString(templateContent, {
+      fields: fields,
+      extendedFields: extendedFields,
+      options: options,
+      data: data,
+      confirmLink: confirmLink
+    })
+
+    if (emailContent.trim() === '') {
+      throw new Error(`The rendered confirmation email content is empty.`)
+    }
+  } catch (error) {
+    console.error(error)
+    console.error(`Using default content for confirmation email.`)
+
+    const confirmTextMarkup = `
+        <!--confirmTextStart-->Please confirm your subscription request by clicking this link:<!--confirmTextEnd-->
+    `
+    const confirmLink = _buildConfirmationLink(confirmTextMarkup, toEmailAddress, fields, options, emailSubject)
+    const confirmLinkShort = confirmLink.substring(0, 100)
+    emailContent = `
+    <html>
+      <body>
+        You have requested to be notified every time a new comment is added to <a href="${options.origin}">${options.origin}</a>.
+        <br>
+        <br>
+        ${confirmTextMarkup} <a href="${confirmLink}">${confirmLinkShort}</a><br>
+        <br>
+      </body>
+    </html>
+    `
+  }
+  return emailContent
+}
+
+const _loadEmailTemplate = async function (subjectOrContent) {
+  /*
+   * Expect a Nunjucks template file to be found at the root of the codebase, available for
+   * customization.
+   */
+  const templateContent = await readFileAsync(
+    path.join(__dirname, '/../email-confirmation-' + subjectOrContent + '.njk'), {
+      encoding: 'utf8'
+    }
+  )
+
+  if (templateContent === null || templateContent.trim() === '') {
+    throw new Error(`Contents of the loaded confirmation email ${subjectOrContent} template are empty.`)
+  } else {
+    return templateContent
+  }
+}
+
+const _buildConfirmationLink = function (templateContent, toEmailAddress, fields, options, emailSubject) {
+  /*
+   * The templateContent argument is expected to contain a portion that is delimited with
+   * <!--confirmTextStart--> and <!--confirmTextEnd-->, which will be extracted to be used as the
+   * confirmation text (audit field).
+   */
+  const idx1 = templateContent.indexOf(confirmTextDelimiterStart) + confirmTextDelimiterStart.length
+  const idx2 = templateContent.indexOf(confirmTextDelimiterEnd)
+  const confirmText = templateContent.substring(idx1, idx2)
+  const encryptedText = _encryptConfirmationLink(toEmailAddress, fields, options, emailSubject, confirmText)
+
+  /*
+   * All of the data needed to process a subscription confirmation (aside from values contained in
+   * the URL path such as repo, branch, etc.) are passed in the "data" querystring value. This is
+   * a win from a privacy perspective, as we won't add them to a mailing list until they confirm.
+   * It also prevents the mailing lists from getting filled-up with spam email addresses. When the
+   * user clicks the link from the received confirmation email, logic in the targeted Staticman
+   * endpoint will decrypt it and use the data to subscribe the user.
+   */
+  const confirmLink = options.subscribeConfirmUrl + '?data=' + encodeURIComponent(encryptedText)
+  return confirmLink
+}
+
+const _encryptConfirmationLink = function (toEmailAddress, fields, options, emailSubject, confirmText) {
+  let toEncrypt = {
+    subscriberEmailAddress: toEmailAddress,
+    parent: options.parent,
+    parentName: options.parentName
+  }
+  Object.assign(toEncrypt, _buildConsentData(options))
+  Object.assign(toEncrypt, {
+    subscribeConfirmContext: 'Email "' + emailSubject.trim() + '"',
+    subscribeConfirmText: confirmText,
+    subscribeConfirmRedirect: options.subscribeConfirmRedirect,
+    subscribeConfirmRedirectError: options.subscribeConfirmRedirectError
+  })
+
+  const encryptedText = RSA.encrypt(JSON.stringify(toEncrypt))
+  return encryptedText
+}
+
+const _buildConsentData = function (options) {
+  let result = {
+    subscribeConsentDate: Math.floor(new Date().getTime() / 1000),
+    subscribeConsentUrl: options.subscribeConsentUrl,
+    subscribeConsentContext: options.subscribeConsentContext,
+    subscribeConsentText: options.subscribeConsentText
+  }
+
+  /*
+   * If the given options contain a consent date, use that instead of the timestamp generated
+   * by default (above). This is expected to be the case if double opt-in is enabled, in which
+   * case the consent date would be set to be when the confirmation email was sent.
+   */
+  if (typeof options.subscribeConsentDate !== 'undefined' && options.subscribeConsentDate !== null) {
+    result.subscribeConsentDate = options.subscribeConsentDate
+  }
+
+  /*
+   * If the consent URL is not explicitly set, use the origin (the URL of the entry being
+   * subscribed to).
+   */
+  if (result.subscribeConsentUrl === null || typeof result.subscribeConsentUrl === 'undefined') {
+    // options.origin should contain the full URL of the entry being subscribed to.
+    result.subscribeConsentUrl = options.origin
+  }
+
+  /*
+   * If the consent context is not explicitly set, use the parent name (a human-readable
+   * name/description of what is being subscribed to.)
+   */
+  if (result.subscribeConsentContext === null || typeof result.subscribeConsentContext === 'undefined') {
+    /*
+     * options.parentName should contain a human-readable name/description of what is being
+     * subscribed to.
+     */
+    result.subscribeConsentContext = options.parentName
+  }
+
+  return result
+}

--- a/lib/Confirmation.js
+++ b/lib/Confirmation.js
@@ -193,6 +193,16 @@ const _encryptConfirmationLink = function (toEmailAddress, fields, options, emai
     subscribeConfirmRedirectError: options.subscribeConfirmRedirectError
   })
 
+  /*
+   * Insert a pepper into the payload. More info - https://en.wikipedia.org/wiki/Pepper_(cryptography)
+   * We do this because the "encrypt" endpoint is currently exposed for anyone to hit. As such, an
+   * attacker could easily create their own valid encrypted strings and subscribe whoever they
+   * want. They'd be able to see the expected structure of the payload data simply by looking at
+   * the source code. Inserting a secret into the payload allows us to verify the authenticity of
+   * the encrypted payload when it is submitted back.
+   */
+  toEncrypt.pepper = config.get('cryptoPepper')
+
   const encryptedText = RSA.encrypt(JSON.stringify(toEncrypt))
   return encryptedText
 }

--- a/lib/Notification.js
+++ b/lib/Notification.js
@@ -12,59 +12,6 @@ const Notification = function (mailAgent) {
   this.mailAgent = mailAgent
 }
 
-Notification.prototype._buildSubject = async function (fields, extendedFields, options, data) {
-  const templateContent = await this._loadEmailTemplate('subject',
-    `There is a new comment at {{ data.siteName }}`)
-  const subject = nunjucks.renderString(templateContent, {
-    fields: fields,
-    extendedFields: extendedFields,
-    options: options,
-    data: data
-  })
-  return subject
-}
-
-Notification.prototype._buildMessage = async function (fields, extendedFields, options, data) {
-  const templateContent = await this._loadEmailTemplate('content', `
-    <html>
-      <body>
-        <h2>There is a new comment at <a href="{{ options.origin }}">{{ options.origin }}</a>.</h2>
-        <br>
-        If you prefer, you may <a href="%mailing_list_unsubscribe_url%">unsubscribe</a> from future emails.<br>
-        <br>
-      </body>
-    </html>
-    `
-  )
-  const emailContent = nunjucks.renderString(templateContent, {
-    fields: fields,
-    extendedFields: extendedFields,
-    options: options,
-    data: data
-  })
-  return emailContent
-}
-
-Notification.prototype._loadEmailTemplate = async function (subjectOrContent, defaultResult) {
-  let templateContent = null
-  try {
-    /*
-     * Expect a Nunjucks template file to be found at the root of the codebase, available for
-     * customization.
-     */
-    templateContent = await readFileAsync(
-      path.join(__dirname, '/../email-notification-' + subjectOrContent + '.njk'), {
-        encoding: 'utf8'
-      })
-  } catch (error) {
-    console.error(error)
-    console.error('Sending notification email using default ' + subjectOrContent + '.')
-
-    templateContent = defaultResult
-  }
-  return templateContent
-}
-
 /**
  * Send an email to the identified mailing list to notify the list member(s) that a new comment
  * has been posted.
@@ -80,7 +27,7 @@ Notification.prototype._loadEmailTemplate = async function (subjectOrContent, de
  *  was submitted. Mostly metadata, including the origin site, ID of the comment's parent, etc.
  * @param data {Object} - Simple mapping of key-value pairs containing any other pertinent data,
  *  such as configuration parameters.
- * return {Promise} - provided as part of submitting to the mailing list agent.
+ * return {Promise} - resolvable to the result of attempting to send the email.
  */
 Notification.prototype.send = function (to, fields, extendedFields, options, data) {
   return new Promise(async (resolve, reject) => {
@@ -89,8 +36,8 @@ Notification.prototype.send = function (to, fields, extendedFields, options, dat
       to
     }
 
-    payload.subject = await this._buildSubject(fields, extendedFields, options, data)
-    payload.html = await this._buildMessage(fields, extendedFields, options, data)
+    payload.subject = await _buildSubject(fields, extendedFields, options, data)
+    payload.html = await _buildMessage(fields, extendedFields, options, data)
 
     /*
      * If we set the "reply_preference" property on the Mailgun mailing list to "sender" (which
@@ -113,3 +60,77 @@ Notification.prototype.send = function (to, fields, extendedFields, options, dat
 }
 
 module.exports = Notification
+
+const _buildSubject = async function (fields, extendedFields, options, data) {
+  let subject = null
+  try {
+    const templateContent = await _loadEmailTemplate('subject')
+    subject = nunjucks.renderString(templateContent, {
+      fields: fields,
+      extendedFields: extendedFields,
+      options: options,
+      data: data
+    })
+
+    if (subject.trim() === '') {
+      throw new Error(`The rendered notification email subject is empty.`)
+    }
+  } catch (error) {
+    console.error(error)
+    console.error(`Using default subject for notification email.`)
+    subject = `There is a new comment at ${data.siteName}`
+  }
+  return subject
+}
+
+const _buildMessage = async function (fields, extendedFields, options, data) {
+  let emailContent = null
+  try {
+    const templateContent = await _loadEmailTemplate('content')
+
+    emailContent = nunjucks.renderString(templateContent, {
+      fields: fields,
+      extendedFields: extendedFields,
+      options: options,
+      data: data
+    })
+
+    if (emailContent.trim() === '') {
+      throw new Error(`The rendered notification email content is empty.`)
+    }
+  } catch (error) {
+    console.error(error)
+    console.error(`Using default content for notification email.`)
+
+    emailContent = `
+    <html>
+      <body>
+        There is a new comment at <a href="${options.origin}">${options.origin}</a>.
+        <br>
+        <br>
+        If you prefer, you may <a href="%mailing_list_unsubscribe_url%">unsubscribe</a> from future emails.<br>
+        <br>
+      </body>
+    </html>
+    `
+  }
+  return emailContent
+}
+
+const _loadEmailTemplate = async function (subjectOrContent) {
+  /*
+   * Expect a Nunjucks template file to be found at the root of the codebase, available for
+   * customization.
+   */
+  const templateContent = await readFileAsync(
+    path.join(__dirname, '/../email-notification-' + subjectOrContent + '.njk'), {
+      encoding: 'utf8'
+    }
+  )
+
+  if (templateContent === null || templateContent.trim() === '') {
+    throw new Error(`Contents of the loaded notification email ${subjectOrContent} template are empty.`)
+  } else {
+    return templateContent
+  }
+}

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -551,7 +551,8 @@ class Staticman {
       if (subscriptions && options.parent && options.subscribe && this.fields[options.subscribe]) {
         // The commenter has indicated that they would like to be notified of future comments.
         const commenterEmailAddress = this.fields[options.subscribe]
-        if (this.siteConfig.get('notifications.doubleOptIn')) {
+        const consentModel = this.siteConfig.get('notifications.consentModel')
+        if (consentModel === 'double') {
           /*
            * If double opt-in is configured, send the commenter an email to confirm their
            * subscription before subscribing them to notification emails.
@@ -571,7 +572,7 @@ class Staticman {
           /*
            * If double opt-in is NOT configured, just go ahead and subscribe them now.
            */
-          await subscriptions.set(options, commenterEmailAddress).catch(err => {
+          await subscriptions.set(options, commenterEmailAddress, this.siteConfig).catch(err => {
             console.error(`Error raised subscribing ${commenterEmailAddress} to comments on ${options.parent}`)
             console.error(err.stack || err)
             /*
@@ -657,7 +658,7 @@ class Staticman {
     return this.getSiteConfig().then(config => {
       const subscriptions = this._initialiseSubscriptions()
 
-      return subscriptions.set(data, data.subscriberEmailAddress)
+      return subscriptions.set(data, data.subscriberEmailAddress, this.siteConfig)
     }).catch(err => {
       return Promise.reject(errorHandler('ERROR_CREATING_SUBSCRIPTION', {
         err,

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -506,6 +506,9 @@ class Staticman {
     this.extendedFields = null
     this.options = Object.assign({}, options)
 
+    let subscribeError = false
+    let subscribeConfirmError = false
+
     return this.getSiteConfig().then(config => {
       return this._checkAuth()
     }).then(() => {
@@ -533,7 +536,7 @@ class Staticman {
 
       // Create file
       return this._createFile(extendedFields)
-    }).then(data => {
+    }).then(async data => {
       const filePath = this._getNewFilePath(fields)
       const subscriptions = this._initialiseSubscriptions()
       const commitMessage = this._resolvePlaceholders(this.siteConfig.get('commitMessage'), {
@@ -541,11 +544,43 @@ class Staticman {
         options
       })
 
-      // Subscribe user, if applicable
+      /*
+       * Handle a request from the commenter to subscribe to comments. This is performed
+       * independently of moderation and acceptance of the comment.
+       */
       if (subscriptions && options.parent && options.subscribe && this.fields[options.subscribe]) {
-        subscriptions.set(options, this.fields[options.subscribe]).catch(err => {
-          console.log(err.stack || err)
-        })
+        // The commenter has indicated that they would like to be notified of future comments.
+        const commenterEmailAddress = this.fields[options.subscribe]
+        if (this.siteConfig.get('notifications.doubleOptIn')) {
+          /*
+           * If double opt-in is configured, send the commenter an email to confirm their
+           * subscription before subscribing them to notification emails.
+           */
+          await subscriptions.sendConfirm(
+            commenterEmailAddress, fields, this.extendedFields, options, this.siteConfig
+          ).catch(err => {
+            console.error(`Error raised sending confirmation email to ${commenterEmailAddress} for ${options.parent}`)
+            console.error(err.stack || err)
+            /*
+             * Allows for tracking this "secondary" error, even if the comment entry is
+             * successfully created via the git service.
+             */
+            subscribeConfirmError = true
+          })
+        } else {
+          /*
+           * If double opt-in is NOT configured, just go ahead and subscribe them now.
+           */
+          await subscriptions.set(options, commenterEmailAddress).catch(err => {
+            console.error(`Error raised subscribing ${commenterEmailAddress} to comments on ${options.parent}`)
+            console.error(err.stack || err)
+            /*
+             * Allows for tracking this "secondary" error, even if the comment entry is
+             * successfully created via the git service.
+             */
+            subscribeError = true
+          })
+        }
       }
 
       if (this.siteConfig.get('moderation')) {
@@ -569,11 +604,22 @@ class Staticman {
         commitMessage
       )
     }).then(result => {
-      return {
+      let returnData = {
         fields: fields,
         redirect: options.redirect ? options.redirect : false
       }
+
+      // If any "secondary" errors were raised, pass them along so they can be reported.
+      if (subscribeError || subscribeConfirmError) {
+        returnData.secondaryErrors = {
+          subscribeError,
+          subscribeConfirmError
+        }
+      }
+
+      return returnData
     }).catch(err => {
+      console.error(err)
       return Promise.reject(errorHandler('ERROR_PROCESSING_ENTRY', {
         err,
         instance: this
@@ -592,6 +638,28 @@ class Staticman {
       return subscriptions.send(options.parent, fields, extendedFields, options, this.siteConfig)
     }).catch(err => {
       return Promise.reject(errorHandler('ERROR_PROCESSING_MERGE', {
+        err,
+        instance: this
+      }))
+    })
+  }
+
+  /**
+   * Subscribe a user to notification emails sent whenever new comments are added (to a post,
+   * parent comment, etc.). It is expected that this is being triggered upon clicking-through
+   * a confirmation email.
+   * @param data {Object} - Contains the context of the original subscription request, including
+   *  subscriber email address, entry being subscribed to, request data, audit fields, etc.
+   * return {Promise} - can be resolved to obtain the result of attempting to subscribe the user
+   *  via the mailing list agent.
+   */
+  async createSubscription (data) {
+    return this.getSiteConfig().then(config => {
+      const subscriptions = this._initialiseSubscriptions()
+
+      return subscriptions.set(data, data.subscriberEmailAddress)
+    }).catch(err => {
+      return Promise.reject(errorHandler('ERROR_CREATING_SUBSCRIPTION', {
         err,
         instance: this
       }))

--- a/lib/SubscriptionsManager.js
+++ b/lib/SubscriptionsManager.js
@@ -88,7 +88,7 @@ SubscriptionsManager.prototype.sendConfirm = function (toEmailAddress, fields, e
   })
 }
 
-SubscriptionsManager.prototype.set = function (data, email) {
+SubscriptionsManager.prototype.set = function (data, email, siteConfig) {
   const entryId = data.parent
 
   return new Promise((resolve, reject) => {
@@ -143,17 +143,18 @@ SubscriptionsManager.prototype.set = function (data, email) {
           address: email
         }
 
+        const consentModel = siteConfig.get('notifications.consentModel')
         /*
-         * If the subscription request data includes audit fields, record them along with the
+         * If an email consent model is configured, record audit fields along with the
          * subscriber's entry in the mailing list.
          */
-        if (data.recordConsent === 'true') {
-          // If requested, record single opt-in ("consent") audit fields.
+        if (consentModel === 'single') {
+          // Record single opt-in ("consent") audit fields.
           payload.vars = Object.assign({}, Confirmation.buildConsentData(data))
-        } else if (data.subscribeConfirmContext || data.subscribeConfirmText) {
+        } else if (consentModel === 'double') {
           /*
-           * Else, if present, record BOTH single opt-in ("consent") audit fields AND double opt-in
-           * ("confirm") audit fields.
+           * Record BOTH single opt-in ("consent") audit fields AND double opt-in ("confirm")
+           * audit fields.
            */
           payload.vars = Object.assign({}, Confirmation.buildConsentData(data))
 

--- a/lib/SubscriptionsManager.js
+++ b/lib/SubscriptionsManager.js
@@ -1,25 +1,194 @@
 'use strict'
 
 const md5 = require('md5')
+const Confirmation = require('./Confirmation')
 const Notification = require('./Notification')
 
 const SubscriptionsManager = function (parameters, dataStore, mailAgent) {
   this.parameters = parameters
   this.dataStore = dataStore
   this.mailAgent = mailAgent
+
+  this.listAddressParams = {
+    username: parameters.username,
+    repository: parameters.repository,
+    mailAgent: mailAgent
+  }
 }
 
-SubscriptionsManager.prototype._getListAddress = function (entryId) {
-  const compoundId = md5(`${this.parameters.username}-${this.parameters.repository}-${entryId}`)
+SubscriptionsManager.prototype.send = function (entryId, fields, extendedFields, options, siteConfig) {
+  return _get(entryId, this.listAddressParams).then(listAddress => {
+    if (listAddress) {
+      /*
+       * Only send a notification email if the commenter is NOT the only subscriber found in the
+       * mailing list. This avoids the clumsy scenario where someone makes the first comment on a
+       * post (while choosing to subscribe to future comments) and then is sent a notification
+       * email for their own comment.
+       */
+      return _calcIsCommenterNotOnlySubscriber(listAddress, fields.email, this.mailAgent).then((result) => {
+        if (result === true) {
+          const notifications = new Notification(this.mailAgent)
 
-  return `${compoundId}@${this.mailAgent.domain}`
+          return notifications.send(listAddress, fields, extendedFields, options, {
+            siteName: siteConfig.get('name')
+          })
+        } else {
+          /*
+           * Don't send an email to notify the commenter of their own comment.
+           */
+          const msg = 'Commenter is the only subscriber. Suppressing notification.'
+          console.log(msg)
+          return msg
+        }
+      })
+    }
+  })
 }
 
-SubscriptionsManager.prototype._get = function (entryId) {
-  const listAddress = this._getListAddress(entryId)
+/**
+ * Send an email to obtain a confirmation that a user wants to subscribe to notification emails
+ * sent whenever new comments are added (to a post, parent comment, etc.). If the given email
+ * address is already subscribed, the email will not be sent.
+ * @param toEmailAddress {String} - The email address to send the confirmation email to.
+ * @param fields {Object} - Simple mapping of "fields" key-value pairs gathered when the
+ *  triggering comment was submitted, moderately processed. Mostly contains data provided by the
+ *  commenter, including the comment, comment author, and commenter email address (hashed).
+ *  However, any Staticman-generated comment date ends up in here, too.
+ * @param extendedFields {Object} - Simple mapping of key-value pairs generated when the triggering
+ *  comment was submitted, fully processed. In addition to the data found in the "fields"
+ *  parameter, also includes the Staticman-generated comment ID.
+ * @param options {Object} - Simple mapping of "options" key-value pairs gathered when the
+ *  triggering comment was submitted. Mostly metadata, including the origin site, ID of the
+ *  comment's parent, etc.
+ * @param siteConfig {Object} - Staticman configuration data.
+ * @return {Promise} - resolvable to the result of attempting to send the email or an indication
+ *  that the email was supressed.
+ */
+SubscriptionsManager.prototype.sendConfirm = function (toEmailAddress, fields, extendedFields, options, siteConfig) {
+  const entryId = options.parent
+
+  return _get(entryId, this.listAddressParams).then(list => {
+    return _determineIfConfirmNeeded(toEmailAddress, list, entryId, this.listAddressParams).then(isConfirmNeeded => {
+      if (isConfirmNeeded === true) {
+        const confirmation = new Confirmation(this.mailAgent)
+
+        const result = confirmation.send(toEmailAddress, fields, extendedFields, options, {
+          siteName: siteConfig.get('name')
+        })
+        return result
+      } else {
+        /*
+         * Don't send an email to confirm the commenter's subscription.
+         */
+        const msg = `${toEmailAddress} already subscribed to ${entryId}. Suppressing confirmation.`
+        console.log(msg)
+        return msg
+      }
+    })
+  })
+}
+
+SubscriptionsManager.prototype.set = function (data, email) {
+  const entryId = data.parent
 
   return new Promise((resolve, reject) => {
-    this.mailAgent.lists(listAddress).info((err, value) => {
+    let queue = []
+
+    return _get(entryId, this.listAddressParams).then(list => {
+      const listAddress = _getListAddress(entryId, this.listAddressParams)
+      if (!list) {
+        queue.push(new Promise((resolve, reject) => {
+          let payload = {
+            address: listAddress
+          }
+          /*
+           * Only allow authenticated users to post to the list. This is the default, but let's
+           * explicitly set it in case the default changes.
+           */
+          payload.access_level = 'readonly'
+
+          /*
+           * Restricting replies to "sender" (as opposed to all members of the list) would seem
+           * to be the safest and most appropriate option for a list meant to receive
+           * notifications.
+           */
+          payload.reply_preference = 'sender'
+
+          const entryName = data.parentName
+          if (typeof entryName !== 'undefined') {
+            /*
+             * Set a name and description on the created list to aid in identification and
+             * troubleshooting, as the automatically-generated list address is an obfuscated
+             * hash value.
+             */
+            payload.name = entryName
+            /*
+             * For the description, include the elements that are used to generate the list
+             * address hash value.
+             */
+            payload.description = 'Subscribers to ' + entryId +
+              ' (' + this.parameters.username + '/' + this.parameters.repository + ')'
+          }
+
+          this.mailAgent.lists().create(payload, (err, result) => {
+            if (err) return reject(err)
+
+            return resolve(result)
+          })
+        }))
+      }
+
+      return Promise.all(queue).then(() => {
+        let payload = {
+          address: email
+        }
+
+        /*
+         * If the subscription request data includes audit fields, record them along with the
+         * subscriber's entry in the mailing list.
+         */
+        if (data.recordConsent === 'true') {
+          // If requested, record single opt-in ("consent") audit fields.
+          payload.vars = Object.assign({}, Confirmation.buildConsentData(data))
+        } else if (data.subscribeConfirmContext || data.subscribeConfirmText) {
+          /*
+           * Else, if present, record BOTH single opt-in ("consent") audit fields AND double opt-in
+           * ("confirm") audit fields.
+           */
+          payload.vars = Object.assign({}, Confirmation.buildConsentData(data))
+
+          payload.vars.subscribeConfirmDate = Math.floor(new Date().getTime() / 1000)
+          payload.vars.subscribeConfirmContext = data.subscribeConfirmContext
+          payload.vars.subscribeConfirmText = data.subscribeConfirmText
+        }
+
+        this.mailAgent.lists(listAddress).members().create(payload, (err, result) => {
+          // A 400 is fine-ish, means the address already exists
+          if (err && (err.statusCode !== 400)) return reject(err)
+
+          return resolve(result)
+        })
+      })
+    }).catch(error => {
+      reject(error)
+    })
+  })
+}
+
+module.exports = SubscriptionsManager
+
+const _getListAddress = function (entryId, listAddressParams) {
+  const compoundId = md5(`${listAddressParams.username}-${listAddressParams.repository}-${entryId}`)
+
+  return `${compoundId}@${listAddressParams.mailAgent.domain}`
+}
+
+const _get = function (entryId, listAddressParams) {
+  const mailAgent = listAddressParams.mailAgent
+  const listAddress = _getListAddress(entryId, listAddressParams)
+
+  return new Promise((resolve, reject) => {
+    mailAgent.lists(listAddress).info((err, value) => {
       if (err && (err.statusCode !== 404)) {
         return reject(err)
       }
@@ -35,11 +204,13 @@ SubscriptionsManager.prototype._get = function (entryId) {
 
 /**
  * Return true if the commenter (as identified by the given hash of their email address) is NOT
- * the only subscriber in the identified mailing list, else false.
+ * the only subscriber in the identified mailing list, else false. We have to use the hashed
+ * email address because this can be invoked as part of merging in a comment, when the unhashed
+ * email address is not available.
  */
-SubscriptionsManager.prototype._calcIsCommenterNotOnlySubscriber = async function (listAddress, commenterEmailHashed) {
+const _calcIsCommenterNotOnlySubscriber = async function (listAddress, commenterEmailHashed, mailAgent) {
   return new Promise((resolve, reject) => {
-    this.mailAgent.lists(listAddress).members().list((err, result) => {
+    mailAgent.lists(listAddress).members().list((err, result) => {
       /*
        * By default, assume the posture that there are other interested parties that should be
        * notified.
@@ -77,97 +248,44 @@ SubscriptionsManager.prototype._calcIsCommenterNotOnlySubscriber = async functio
   })
 }
 
-SubscriptionsManager.prototype.send = function (entryId, fields, extendedFields, options, siteConfig) {
-  return this._get(entryId).then(listAddress => {
-    if (listAddress) {
-      /*
-       * Only send a notification email if the commenter is NOT the only subscriber found in the
-       * mailing list. This avoids the clumsy scenario where someone makes the first comment on a
-       * post (while choosing to subscribe to future comments) and then is sent a notification
-       * email for their own comment.
-       */
-      return this._calcIsCommenterNotOnlySubscriber(listAddress, fields.email).then((result) => {
-        if (result === true) {
-          const notifications = new Notification(this.mailAgent)
-
-          return notifications.send(listAddress, fields, extendedFields, options, {
-            siteName: siteConfig.get('name')
-          })
-        } else {
+const _determineIfConfirmNeeded = function (toEmailAddress, list, entryId, listAddressParams) {
+  const mailAgent = listAddressParams.mailAgent
+  return new Promise(async (resolve, reject) => {
+    // By default, assume that a confirmation email should be sent.
+    let isConfirmNeeded = true
+    if (list) {
+      const listAddress = _getListAddress(entryId, listAddressParams)
+      await mailAgent.lists(listAddress).members(toEmailAddress).info((err, result) => {
+        if (err) {
           /*
-           * Don't send an email to notify the commenter of their own comment.
+           * If the member is not found in the mailing list, an error will be raised. Seems a
+           * bit clumsy.
            */
-          console.log('Commenter is the only subscriber. Suppressing notification.')
+          console.error(`${toEmailAddress} not found in mailing list for ${entryId} (or error raised). Sending confirmation.`)
+        } else {
+          // Found the context commenter in the mailing list.
+          try {
+            if (result.member.subscribed) {
+              /*
+               * If the context commenter is already included in the mailing list and marked as
+               * subscribed, there is no need to get another confirmation from them.
+               */
+              isConfirmNeeded = false
+            }
+          } catch (error) {
+            console.error(error)
+            console.error(`Error determining if ${toEmailAddress} already subscribed to ${entryId}. Assuming not.`)
+          }
         }
+
+        return resolve(isConfirmNeeded)
       })
+    } else {
+      /*
+       * If a mailing list doesn't exist for the parent, nobody is subscribed, including the
+       * context commenter. Confirmation is needed.
+       */
+      return resolve(isConfirmNeeded)
     }
   })
 }
-
-SubscriptionsManager.prototype.set = function (options, email) {
-  const entryId = options.parent
-  const listAddress = this._getListAddress(entryId)
-
-  return new Promise((resolve, reject) => {
-    let queue = []
-
-    return this._get(entryId).then(list => {
-      if (!list) {
-        queue.push(new Promise((resolve, reject) => {
-          let payload = {
-            address: listAddress
-          }
-          /*
-           * Only allow authenticated users to post to the list. This is the default, but let's
-           * explicitly set it in case the default changes.
-           */
-          payload.access_level = 'readonly'
-
-          /*
-           * Restricting replies to "sender" (as opposed to all members of the list) would seem
-           * to be the safest and most appropriate option for a list meant to receive
-           * notifications.
-           */
-          payload.reply_preference = 'sender'
-
-          const entryName = options.parentName
-          if (typeof entryName !== 'undefined') {
-            /*
-             * Set a name and description on the created list to aid in identification and
-             * troubleshooting, as the automatically-generated list address is an obfuscated
-             * hash value.
-             */
-            payload.name = entryName
-            /*
-             * For the description, include the elements that are used to generate the list
-             * address hash value.
-             */
-            payload.description = 'Subscribers to ' + entryId +
-              ' (' + this.parameters.username + '/' + this.parameters.repository + ')'
-          }
-
-          this.mailAgent.lists().create(payload, (err, result) => {
-            if (err) return reject(err)
-
-            return resolve(result)
-          })
-        }))
-      }
-
-      return Promise.all(queue).then(() => {
-        this.mailAgent.lists(listAddress).members().create({
-          address: email
-        }, (err, result) => {
-          // A 400 is fine-ish, means the address already exists
-          if (err && (err.statusCode !== 400)) return reject(err)
-
-          return resolve(result)
-        })
-      })
-    }).catch(error => {
-      reject(error)
-    })
-  })
-}
-
-module.exports = SubscriptionsManager

--- a/server.js
+++ b/server.js
@@ -14,7 +14,8 @@ class StaticmanAPI {
       handlePR: require('./controllers/handlePR'),
       home: require('./controllers/home'),
       process: require('./controllers/process'),
-      webhook: require('./controllers/webhook')
+      webhook: require('./controllers/webhook'),
+      confirmSubscription: require('./controllers/confirmSubscription')
     }
 
     this.server = express()
@@ -103,6 +104,14 @@ class StaticmanAPI {
       this.requireApiVersion([3]),
       this.requireService(['gitlab']),
       this.controllers.webhook
+    )
+
+    this.server.get(
+      '/v:version/confirm/:service/:username/:repository/:branch/:property',
+      this.bruteforce.prevent,
+      this.requireApiVersion([3]),
+      this.requireService(['github', 'gitlab']),
+      this.controllers.confirmSubscription
     )
 
     // Route: root

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -141,6 +141,11 @@ const schema = {
       format: Boolean,
       default: false
     },
+    doubleOptIn: {
+      doc: 'Whether commenters are required to confirm their subscription request via a confirmation email. A [Mailgun](http://mailgun.com) account is required.',
+      format: Boolean,
+      default: false
+    },
     apiKey: {
       doc: 'Mailgun API key',
       format: 'EncryptedString',

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -141,10 +141,10 @@ const schema = {
       format: Boolean,
       default: false
     },
-    doubleOptIn: {
-      doc: 'Whether commenters are required to confirm their subscription request via a confirmation email. A [Mailgun](http://mailgun.com) account is required.',
-      format: Boolean,
-      default: false
+    consentModel: {
+      doc: 'The consent/confirm model to enforce for notifications. If "none", users are subscribed to notifications immediately, with no consent data recorded. If "single", users are subscribed to notifications immediately, with consent data recorded. If "double", users are subscribed to notifications only after confirming via an email click-through, with consent and confirm data recorded.',
+      format: ['none', 'single', 'double'],
+      default: 'none'
     },
     apiKey: {
       doc: 'Mailgun API key',

--- a/test/unit/controllers/confirmSubscription.test.js
+++ b/test/unit/controllers/confirmSubscription.test.js
@@ -1,0 +1,154 @@
+const config = require('./../../../config')
+
+const mockHelpers = require('./../../helpers')
+
+let req
+let res
+let next
+
+const mockEncryptedData = 'YqzGG8EeqlzwyZ9qgYCXzFsg5+iS0Ht8Rr79'
+const mockConfirmData = {
+  subscriberEmailAddress: 'john.doe@example.com',
+  parent: 'an-awesome-post-about-staticman',
+  parentName: 'An Awesome Post About Staticman',
+  subscribeConsentDate: 1607380281,
+  subscribeConsentUrl: 'mock subscribe consent url',
+  subscribeConsentContext: 'mock subscribe consent context',
+  subscribeConsentText: 'mock subscribe consent text',
+  subscribeConfirmContext: 'Email "Mock subscription confirmation for Test blog"',
+  subscribeConfirmText: 'Mock confirm text!',
+  subscribeConfirmRedirect: 'https://example.com/redirect',
+  subscribeConfirmRedirectError: 'https://example.com/redirectError',
+  pepper: 'mock crypto pepper'
+}
+
+let mockDecryptFunc = jest.fn()
+jest.mock('./../../../lib/RSA', () => {
+  return {
+    decrypt: mockDecryptFunc
+  }
+})
+
+let mockSendResponseFn = jest.fn()
+// The sendResponse module exposes one "naked" function.
+jest.mock('../../../controllers/sendResponse', () => {
+  return mockSendResponseFn
+})
+
+let mockSetConfigPathFn = jest.fn()
+let mockCreateSubscriptionFn = jest.fn()
+jest.mock('../../../lib/Staticman', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      setConfigPath: mockSetConfigPathFn,
+      createSubscription: mockCreateSubscriptionFn
+    }
+  })
+})
+
+// Instantiate the module being tested AFTER mocking dependendent modules above.
+const confirmSubscription = require('../../../controllers/confirmSubscription')
+
+beforeEach(() => {
+  req = mockHelpers.getMockRequest()
+  req.query = {
+  	data: mockEncryptedData
+  }
+
+  res = mockHelpers.getMockResponse()
+
+  mockDecryptFunc.mockImplementation((encryptedDataStr) => {
+  	return JSON.stringify(mockConfirmData)
+  })
+
+  config.set('cryptoPepper', mockConfirmData.pepper)
+})
+
+afterEach(() => {
+  mockDecryptFunc.mockClear()
+  mockSendResponseFn.mockClear()
+  mockSetConfigPathFn.mockClear()
+  mockCreateSubscriptionFn.mockClear()
+})
+
+describe('confirmSubscription', () => {
+  test('abort and return error if confirm data not supplied', () => {
+  	mockDecryptFunc.mockImplementation((encryptedDataStr) => null)
+
+	// Suppress any calls to console.error - to keep test output clean.
+	const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect.hasAssertions()
+    return confirmSubscription(req, res, next).then(() => {
+      expect(mockDecryptFunc.mock.calls[0][0]).toEqual(mockEncryptedData)
+      expect(mockCreateSubscriptionFn).toHaveBeenCalledTimes(0)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1]).toEqual({
+      	err: new Error('Authenticity check failed.')
+      })
+
+	  // Restore console.error
+	  consoleSpy.mockRestore()
+    })
+  })
+
+  test('abort and return error if crypto pepper mismatch', () => {
+  	config.set('cryptoPepper', mockConfirmData.pepper + ' different')
+
+	// Suppress any calls to console.error - to keep test output clean.
+	const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect.hasAssertions()
+    return confirmSubscription(req, res, next).then(() => {
+      expect(mockDecryptFunc.mock.calls[0][0]).toEqual(mockEncryptedData)
+      expect(mockCreateSubscriptionFn).toHaveBeenCalledTimes(0)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1]).toEqual({
+      	err: new Error('Authenticity check failed.'),
+      	redirectError: mockConfirmData.subscribeConfirmRedirectError
+      })
+
+	  // Restore console.error
+	  consoleSpy.mockRestore()
+    })
+  })
+
+  test('abort and return error if create subscription fails', () => {
+  	const mockError = 'mock error'
+  	mockCreateSubscriptionFn.mockImplementation((confirmData) => Promise.reject( mockError ))
+
+	// Suppress any calls to console.error - to keep test output clean.
+	const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect.hasAssertions()
+    return confirmSubscription(req, res, next).then(() => {
+      expect(mockDecryptFunc.mock.calls[0][0]).toEqual(mockEncryptedData)
+      expect(mockCreateSubscriptionFn).toHaveBeenCalledTimes(1)
+      expect(mockCreateSubscriptionFn.mock.calls[0][0]).toEqual(mockConfirmData)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1]).toEqual({
+      	err: mockError,
+      	redirectError: mockConfirmData.subscribeConfirmRedirectError
+      })
+
+	  // Restore console.error
+	  consoleSpy.mockRestore()
+    })
+  })
+
+  test('return response if create subscription succeeds', () => {
+  	mockCreateSubscriptionFn.mockImplementation((confirmData) => Promise.resolve( {} ))
+
+    expect.hasAssertions()
+    return confirmSubscription(req, res, next).then(() => {
+      expect(mockDecryptFunc.mock.calls[0][0]).toEqual(mockEncryptedData)
+      expect(mockCreateSubscriptionFn).toHaveBeenCalledTimes(1)
+      expect(mockCreateSubscriptionFn.mock.calls[0][0]).toEqual(mockConfirmData)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1]).toEqual({
+      	redirect: mockConfirmData.subscribeConfirmRedirect
+      })
+    })
+  })
+
+})

--- a/test/unit/controllers/process.test.js
+++ b/test/unit/controllers/process.test.js
@@ -269,44 +269,6 @@ describe('Process controller', () => {
     })
   })
 
-  describe('createConfigObject', () => {
-    const createConfigObject = require('./../../../controllers/process').createConfigObject
-
-    test('creates a config object for version 1 of API', () => {
-      const configv1 = {
-        file: '_config.yml',
-        path: 'staticman'
-      }
-
-      const config1 = createConfigObject('1')
-      const config2 = createConfigObject('1', 'someProperty')
-
-      expect(config1).toEqual(configv1)
-      expect(config2).toEqual(configv1)
-    })
-
-    test('creates a config object for version 2+ of API', () => {
-      const configv2File = 'staticman.yml'
-
-      const config3 = createConfigObject('2')
-      const config4 = createConfigObject('2', 'someProperty')
-      const config5 = createConfigObject()
-
-      expect(config3).toEqual({
-        file: configv2File,
-        path: ''
-      })
-      expect(config4).toEqual({
-        file: configv2File,
-        path: 'someProperty'
-      })
-      expect(config5).toEqual({
-        file: configv2File,
-        path: ''
-      })
-    })
-  })
-
   describe('process', () => {
     const processFn = require('./../../../controllers/process').process
 

--- a/test/unit/controllers/process.test.js
+++ b/test/unit/controllers/process.test.js
@@ -1,3 +1,5 @@
+const { URL, URLSearchParams } = require('url')
+
 const config = require('./../../../config')
 const errorHandler = require('./../../../lib/ErrorHandler').getInstance()
 const githubToken = config.get('githubToken')
@@ -309,7 +311,7 @@ describe('Process controller', () => {
     const processFn = require('./../../../controllers/process').process
 
     test('send a redirect to the URL provided, if the `redirect` option is provided, if `processEntry` succeeds', () => {
-      const redirectUrl = 'https://eduardoboucas.com'
+      const redirectUrl = new URL('https://eduardoboucas.com').toString()
       const mockProcessEntry = jest.fn((fields, options) => Promise.resolve({
         fields: ['name', 'email'],
         redirect: redirectUrl
@@ -428,11 +430,11 @@ describe('Process controller', () => {
   })
 
   describe('sendResponse', () => {
-    const sendResponse = require('./../../../controllers/process').sendResponse
+    const sendResponse = require('./../../../controllers/sendResponse')
 
     test('redirects if there is a `redirect` option and no errors', () => {
       const data = {
-        redirect: 'https://eduardoboucas.com'
+        redirect: new URL('https://eduardoboucas.com').toString()
       }
 
       const res = mockHelpers.getMockResponse()

--- a/test/unit/controllers/process.test.js
+++ b/test/unit/controllers/process.test.js
@@ -1,470 +1,306 @@
 const { URL, URLSearchParams } = require('url')
 
-const config = require('./../../../config')
-const errorHandler = require('./../../../lib/ErrorHandler').getInstance()
-const githubToken = config.get('githubToken')
 const mockHelpers = require('./../../helpers')
-const sampleData = require('./../../helpers/sampleData')
 
-let mockSiteConfig
 let req
+let res
+let next
+
+const mockRedirect = 'https://example.com/redirect'
+const mockRedirectError = 'https://example.com/redirectError'
+const mockUserAgent = 'Firefox'
+const mockReCaptchaSiteKey = 'mock reCaptcha site key'
+const mockReCaptchaSecret = 'mock reCaptcha secret'
+const mockReCaptchaSecretDecrypted = 'mock reCaptcha secret decrypted'
+
+let mockSetConfigPathFn = jest.fn()
+let mockGetSiteConfigFn = jest.fn()
+let mockSetIpFn = jest.fn()
+let mockSetUserAgentFn = jest.fn()
+let mockDecryptFn = jest.fn()
+let mockProcessEntryFn = jest.fn()
+jest.mock('../../../lib/Staticman', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      setConfigPath: mockSetConfigPathFn,
+      getSiteConfig: mockGetSiteConfigFn,
+      setIp: mockSetIpFn,
+      setUserAgent: mockSetUserAgentFn,
+      decrypt: mockDecryptFn,
+      processEntry: mockProcessEntryFn
+    }
+  })
+})
+
+let mockSendResponseFn = jest.fn()
+// The sendResponse module exposes one "naked" function.
+jest.mock('../../../controllers/sendResponse', () => {
+  return mockSendResponseFn
+})
+
+let mockErrorHandlerFn = jest.fn()
+jest.mock('../../../lib/ErrorHandler', () => {
+  return mockErrorHandlerFn
+})
+mockErrorHandlerFn.mockImplementation((errorStr) => new Error(errorStr))
+
+let mockReCaptchaInitFn = jest.fn()
+let mockReCaptchaVerifyFn = jest.fn()
+jest.mock('express-recaptcha', () => {
+  return {
+    init: mockReCaptchaInitFn,
+    verify: mockReCaptchaVerifyFn
+  }
+})
+
+// Instantiate the module being tested AFTER mocking dependendent modules above.
+const process = require('../../../controllers/process')
 
 beforeEach(() => {
-  jest.resetModules()
-
-  mockSiteConfig = mockHelpers.getConfig()
-
   req = mockHelpers.getMockRequest()
+  req.headers['user-agent'] = mockUserAgent
+
+  req.body = {
+    options: {
+      redirect: mockRedirect,
+      redirectError: mockRedirectError
+    }
+  }
+})
+
+afterEach(() => {
+  mockSetConfigPathFn.mockClear()
+  mockGetSiteConfigFn.mockClear()
+  mockSetIpFn.mockClear()
+  mockSetUserAgentFn.mockClear()
+  mockDecryptFn.mockClear()
+  mockProcessEntryFn.mockClear()
+
+  mockSendResponseFn.mockClear()
+
+  mockErrorHandlerFn.mockClear()
+
+  mockReCaptchaInitFn.mockClear()
+  mockReCaptchaVerifyFn.mockClear()
 })
 
 describe('Process controller', () => {
-  describe('checkRecaptcha', () => {
-    test('does nothing if reCaptcha is not enabled in config', () => {
-      mockSiteConfig.set('reCaptcha.enabled', false)
+  test('abort and return an error if reCaptcha enabled but reCaptcha credentials not supplied in request', () => {
+    mockGetSiteConfigFn.mockImplementation(() => new Promise((resolve, reject) => resolve(new Map([
+        ['reCaptcha.enabled', true]
+      ])))
+    )
 
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          getSiteConfig: () => Promise.resolve(mockSiteConfig)
-        }))
-      })
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      return checkRecaptcha(staticman, req).then(response => {
-        expect(response).toBe(false)
-      })
-    })
-
-    test('throws an error if reCaptcha block is not in the request body', () => {
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          getSiteConfig: () => Promise.resolve(mockSiteConfig)
-        }))
-      })
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      mockSiteConfig.set('reCaptcha.enabled', true)
-
-      req.body = {
-        options: {}
-      }
-
-      return checkRecaptcha(staticman, req).catch(err => {
-        expect(err._smErrorCode).toBe('RECAPTCHA_MISSING_CREDENTIALS')
-      })
-    })
-
-    test('throws an error if reCaptcha site key is not in the request body', () => {
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          getSiteConfig: () => Promise.resolve(mockSiteConfig)
-        }))
-      })
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      req.body = {
-        options: {
-          reCaptcha: {
-            secret: '1q2w3e4r'
-          }
-        }
-      }
-
-      return checkRecaptcha(staticman, req).catch(err => {
-        expect(err._smErrorCode).toBe('RECAPTCHA_MISSING_CREDENTIALS')
-      })
-    })
-
-    test('throws an error if reCaptcha secret is not in the request body', () => {
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          getSiteConfig: () => Promise.resolve(mockSiteConfig)
-        }))
-      })
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      req.body = {
-        options: {
-          reCaptcha: {
-            siteKey: '123456789'
-          }
-        }
-      }
-
-      return checkRecaptcha(staticman, req).catch(err => {
-        expect(err._smErrorCode).toBe('RECAPTCHA_MISSING_CREDENTIALS')
-      })
-    })
-
-    test('throws an error if the reCatpcha secret fails to decrypt', () => {
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          decrypt: () => {
-            throw 'someError'
-          },
-          getSiteConfig: () => Promise.resolve(mockSiteConfig)
-        }))
-      })
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      req.body = {
-        options: {
-          reCaptcha: {
-            siteKey: '123456789',
-            secret: '1q2w3e4r'
-          }
-        }
-      }
-
-      return checkRecaptcha(staticman, req).catch(err => {
-        expect(err._smErrorCode).toBe('RECAPTCHA_CONFIG_MISMATCH')
-      })
-    })
-
-    test('throws an error if the reCatpcha siteKey provided does not match the one in config', () => {
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          getSiteConfig: () => Promise.resolve(mockSiteConfig)
-        }))
-      })
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      req.body = {
-        options: {
-          reCaptcha: {
-            siteKey: '987654321',
-            secret: mockSiteConfig.getRaw('reCaptcha.secret')
-          }
-        }
-      }
-
-      return checkRecaptcha(staticman, req).catch(err => {
-        expect(err._smErrorCode).toBe('RECAPTCHA_CONFIG_MISMATCH')
-      })
-    })
-
-    test('throws an error if the reCatpcha secret provided does not match the one in config', () => {
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          getSiteConfig: () => Promise.resolve(mockSiteConfig)
-        }))
-      })
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      req.body = {
-        options: {
-          reCaptcha: {
-            siteKey: mockSiteConfig.get('reCaptcha.siteKey'),
-            secret: mockHelpers.encrypt('some other secret')
-          }
-        }
-      }
-
-      return checkRecaptcha(staticman, req).catch(err => {
-        expect(err._smErrorCode).toBe('RECAPTCHA_CONFIG_MISMATCH')
-      })
-    })
-
-    test('initialises and triggers a verification from the reCaptcha module', () => {
-      const mockInitFn = jest.fn()
-      const mockVerifyFn = jest.fn((req, reCaptchaCallback) => {
-        reCaptchaCallback(false)
-      })
-
-      jest.mock('express-recaptcha', () => {
-        return {
-          init: mockInitFn,
-          verify: mockVerifyFn
-        }
-      })
-
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          decrypt: mockHelpers.decrypt,
-          getSiteConfig: () => Promise.resolve(mockSiteConfig)
-        }))
-      })    
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      req.body = {
-        options: {
-          reCaptcha: {
-            siteKey: mockSiteConfig.get('reCaptcha.siteKey'),
-            secret: mockSiteConfig.getRaw('reCaptcha.secret')
-          }
-        }
-      }
-
-      return checkRecaptcha(staticman, req).then(response => {
-        expect(response).toBe(true)
-        expect(mockInitFn.mock.calls.length).toBe(1)
-        expect(mockInitFn.mock.calls[0][0]).toBe(mockSiteConfig.get('reCaptcha.siteKey'))
-        expect(mockInitFn.mock.calls[0][1]).toBe(mockSiteConfig.get('reCaptcha.secret'))
-        expect(mockVerifyFn.mock.calls[0][0]).toBe(req)
-      })
-    })
-
-    test('displays an error if the reCaptcha verification fails', () => {
-      const reCaptchaError = new Error('someError')
-      const mockInitFn = jest.fn()
-      const mockVerifyFn = jest.fn((req, reCaptchaCallback) => {
-        reCaptchaCallback(reCaptchaError)
-      })
-
-      jest.mock('express-recaptcha', () => {
-        return {
-          init: mockInitFn,
-          verify: mockVerifyFn
-        }
-      })
-
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          decrypt: mockHelpers.decrypt,
-          getSiteConfig: () => Promise.resolve(mockSiteConfig)
-        }))
-      })
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      req.body = {
-        options: {
-          reCaptcha: {
-            siteKey: mockSiteConfig.get('reCaptcha.siteKey'),
-            secret: mockSiteConfig.getRaw('reCaptcha.secret')
-          }
-        }
-      }
-
-      return checkRecaptcha(staticman, req).catch(err => {
-        expect(err).toEqual({
-          _smErrorCode: reCaptchaError
-        })
-      })
+    expect.hasAssertions()
+    return process(req, res, next).then(() => {
+      expect(mockDecryptFn).toHaveBeenCalledTimes(0)
+      expect(mockErrorHandlerFn).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandlerFn.mock.calls[0][0]).toEqual('RECAPTCHA_MISSING_CREDENTIALS')
+      expect(mockSendResponseFn).toHaveBeenCalledTimes(1)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1].err.message).toEqual('RECAPTCHA_MISSING_CREDENTIALS')
+      expect(mockSendResponseFn.mock.calls[0][1].redirect).toEqual(mockRedirect)
+      expect(mockSendResponseFn.mock.calls[0][1].redirectError).toEqual(mockRedirectError)
     })
   })
 
-  describe('process', () => {
-    const processFn = require('./../../../controllers/process').process
+  test('abort and return an error if reCaptcha secret decryption fails', () => {
+    mockGetSiteConfigFn.mockImplementation(() => new Promise((resolve, reject) => resolve(new Map([
+        ['reCaptcha.enabled', true]
+      ])))
+    )
 
-    test('send a redirect to the URL provided, if the `redirect` option is provided, if `processEntry` succeeds', () => {
-      const redirectUrl = new URL('https://eduardoboucas.com').toString()
-      const mockProcessEntry = jest.fn((fields, options) => Promise.resolve({
-        fields: ['name', 'email'],
-        redirect: redirectUrl
-      }))
+    req.body.options.reCaptcha = {
+      siteKey: mockReCaptchaSiteKey, 
+      secret: mockReCaptchaSecret
+    }
 
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          processEntry: mockProcessEntry
-        }))
-      })
-
-      const res = mockHelpers.getMockResponse()
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      req.body = {
-        fields: {
-          name: 'Eduardo Boucas',
-          email: 'mail@eduardoboucas.com'
-        },
-        options: {
-          reCaptcha: {
-            siteKey: mockSiteConfig.get('reCaptcha.siteKey'),
-            secret: mockSiteConfig.getRaw('reCaptcha.secret')
-          },
-          redirect: redirectUrl
-        }
-      }
-      req.query = {}
-
-      return processFn(staticman, req, res).then(response => {
-        expect(res.redirect.mock.calls.length).toBe(1)
-        expect(res.redirect.mock.calls[0][0]).toBe(redirectUrl)
-      })
+    mockDecryptFn.mockImplementation(() => {
+      throw new Error('mock decrypt error')
     })
 
-    test('deliver an object with the processed fields if `processEntry` succeeds', () => {
-      const fields = {
-        name: 'Eduardo Boucas',
-        email: 'mail@eduardoboucas.com'
-      }
-      const mockProcessEntry = jest.fn((fields, options) => Promise.resolve({
-        fields: fields
-      }))
-
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          processEntry: mockProcessEntry
-        }))
-      })
-
-      const res = mockHelpers.getMockResponse()
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      req.body = {
-        fields: fields,
-        options: {
-          reCaptcha: {
-            siteKey: mockSiteConfig.get('reCaptcha.siteKey'),
-            secret: mockSiteConfig.getRaw('reCaptcha.secret')
-          }
-        }
-      }
-      req.query = {}
-
-      return processFn(staticman, req, res).then(response => {
-        expect(res.send.mock.calls.length).toBe(1)
-        expect(res.send.mock.calls[0][0]).toEqual({
-          fields: fields,
-          success: true
-        })
-      })
-    })
-
-    test('reject if `processEntry` fails', () => {
-      const processEntryError = new Error('someError')
-      const mockProcessEntry = jest.fn((fields, options) => {
-        return Promise.reject(processEntryError)
-      })
-
-      jest.mock('./../../../lib/Staticman', () => {
-        return jest.fn(parameters => ({
-          processEntry: mockProcessEntry
-        }))
-      })
-
-      const res = mockHelpers.getMockResponse()
-
-      const checkRecaptcha = require('./../../../controllers/process').checkRecaptcha
-      const Staticman = require('./../../../lib/Staticman')
-      const staticman = new Staticman(req.params)
-
-      req.body = {
-        fields: {
-          name: 'Eduardo Boucas',
-          email: 'mail@eduardoboucas.com'
-        },
-        options: {
-          reCaptcha: {
-            siteKey: mockSiteConfig.get('reCaptcha.siteKey'),
-            secret: mockSiteConfig.getRaw('reCaptcha.secret')
-          }
-        }
-      }
-      req.query = {}
-
-      return processFn(staticman, req, res).catch(err => {
-        expect(err).toEqual(processEntryError)
-      })
+    expect.hasAssertions()
+    return process(req, res, next).then(() => {
+      expect(mockDecryptFn).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandlerFn).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandlerFn.mock.calls[0][0]).toEqual('RECAPTCHA_CONFIG_MISMATCH')
+      expect(mockSendResponseFn).toHaveBeenCalledTimes(1)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1].err.message).toEqual('RECAPTCHA_CONFIG_MISMATCH')
+      expect(mockSendResponseFn.mock.calls[0][1].redirect).toEqual(mockRedirect)
+      expect(mockSendResponseFn.mock.calls[0][1].redirectError).toEqual(mockRedirectError)
     })
   })
 
-  describe('sendResponse', () => {
-    const sendResponse = require('./../../../controllers/sendResponse')
+  test('abort and return an error if reCaptcha site key supplied in request does not match config', () => {
+    mockGetSiteConfigFn.mockImplementation(() => new Promise((resolve, reject) => resolve(new Map([
+        ['reCaptcha.enabled', true],
+        ['reCaptcha.siteKey', mockReCaptchaSiteKey]
+      ])))
+    )
 
-    test('redirects if there is a `redirect` option and no errors', () => {
-      const data = {
-        redirect: new URL('https://eduardoboucas.com').toString()
-      }
+    req.body.options.reCaptcha = {
+      siteKey: mockReCaptchaSiteKey + ' different', 
+      secret: mockReCaptchaSecret
+    }
 
-      const res = mockHelpers.getMockResponse()
-
-      sendResponse(res, data)
-
-      expect(res.redirect.mock.calls.length).toBe(1)
-      expect(res.redirect.mock.calls[0][0]).toBe(data.redirect)
-    })
-
-    test('redirects if there is a `redirectError` option there is an error', () => {
-      const data = {
-        err: 'someError',
-        redirect: 'https://eduardoboucas.com',
-        redirectError: 'https://eduardoboucas.com/error'
-      }
-
-      const res = mockHelpers.getMockResponse()
-
-      sendResponse(res, data)
-
-      expect(res.redirect.mock.calls.length).toBe(1)
-      expect(res.redirect.mock.calls[0][0]).toBe(data.redirectError)
-    })
-
-    test('sends a 200 with a fields object if there are no errors', () => {
-      const data = {
-        fields: {
-          name: 'Eduardo Bouças',
-          email: 'mail@eduardoboucas.com'
-        }
-      }
-
-      const res = mockHelpers.getMockResponse()
-
-      sendResponse(res, data)
-
-      expect(res.send.mock.calls.length).toBe(1)
-      expect(res.send.mock.calls[0][0]).toEqual({
-        success: true,
-        fields: data.fields
-      })
-      expect(res.status.mock.calls.length).toBe(1)
-      expect(res.status.mock.calls[0][0]).toBe(200)
-    })
-
-    test('sends a 500 with an error object if there is an error', () => {
-      const data = {
-        err: {
-          _smErrorCode: 'missing-input-secret'
-        },
-        redirect: 'https://eduardoboucas.com'
-      }
-
-      const res = mockHelpers.getMockResponse()
-
-      sendResponse(res, data)
-
-      expect(res.send.mock.calls.length).toBe(1)
-      expect(res.send.mock.calls[0][0].success).toBe(false)
-      expect(res.send.mock.calls[0][0].message).toBe(
-        errorHandler.getMessage(data.err._smErrorCode)
-      )
-      expect(res.send.mock.calls[0][0].errorCode).toBe(
-        errorHandler.getErrorCode(data.err._smErrorCode)
-      )
-      expect(res.status.mock.calls.length).toBe(1)
-      expect(res.status.mock.calls[0][0]).toBe(500)
+    expect.hasAssertions()
+    return process(req, res, next).then(() => {
+      expect(mockDecryptFn).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandlerFn).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandlerFn.mock.calls[0][0]).toEqual('RECAPTCHA_CONFIG_MISMATCH')
+      expect(mockSendResponseFn).toHaveBeenCalledTimes(1)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1].err.message).toEqual('RECAPTCHA_CONFIG_MISMATCH')
+      expect(mockSendResponseFn.mock.calls[0][1].redirect).toEqual(mockRedirect)
+      expect(mockSendResponseFn.mock.calls[0][1].redirectError).toEqual(mockRedirectError)
     })
   })
+
+  test('abort and return an error if reCaptcha secret supplied in request does not match config', () => {
+    const mockReCaptchaSecretDecryptedExpected = mockReCaptchaSecretDecrypted + ' different'
+    mockGetSiteConfigFn.mockImplementation(() => new Promise((resolve, reject) => resolve(new Map([
+        ['reCaptcha.enabled', true],
+        ['reCaptcha.siteKey', mockReCaptchaSiteKey],
+        ['reCaptcha.secret', mockReCaptchaSecretDecryptedExpected]
+      ])))
+    )
+
+    req.body.options.reCaptcha = {
+      siteKey: mockReCaptchaSiteKey, 
+      secret: mockReCaptchaSecret
+    }
+
+    mockDecryptFn.mockImplementation(() => mockReCaptchaSecretDecrypted)
+
+    expect.hasAssertions()
+    return process(req, res, next).then(() => {
+      expect(mockDecryptFn).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandlerFn).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandlerFn.mock.calls[0][0]).toEqual('RECAPTCHA_CONFIG_MISMATCH')
+      expect(mockSendResponseFn).toHaveBeenCalledTimes(1)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1].err.message).toEqual('RECAPTCHA_CONFIG_MISMATCH')
+      expect(mockSendResponseFn.mock.calls[0][1].redirect).toEqual(mockRedirect)
+      expect(mockSendResponseFn.mock.calls[0][1].redirectError).toEqual(mockRedirectError)
+    })
+  })
+
+  test('abort and return an error if reCaptcha verification fails', () => {
+    mockGetSiteConfigFn.mockImplementation(() => new Promise((resolve, reject) => resolve(new Map([
+        ['reCaptcha.enabled', true],
+        ['reCaptcha.siteKey', mockReCaptchaSiteKey],
+        ['reCaptcha.secret', mockReCaptchaSecretDecrypted]
+      ])))
+    )
+
+    req.body.options.reCaptcha = {
+      siteKey: mockReCaptchaSiteKey, 
+      secret: mockReCaptchaSecret
+    }
+
+    mockDecryptFn.mockImplementation(() => mockReCaptchaSecretDecrypted)
+
+    const mockVerifyError = 'mock reCaptcha verify error'
+    mockReCaptchaVerifyFn.mockImplementation((req, callback) => {
+      callback(mockVerifyError)
+    })
+
+    expect.hasAssertions()
+    return process(req, res, next).then(() => {
+      expect(mockDecryptFn).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandlerFn).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandlerFn.mock.calls[0][0]).toEqual(mockVerifyError)
+      expect(mockSendResponseFn).toHaveBeenCalledTimes(1)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1].err.message).toEqual(mockVerifyError)
+      expect(mockSendResponseFn.mock.calls[0][1].redirect).toEqual(mockRedirect)
+      expect(mockSendResponseFn.mock.calls[0][1].redirectError).toEqual(mockRedirectError)
+    })
+  })
+
+  test('entry processed if reCaptcha disabled', () => {
+    mockGetSiteConfigFn.mockImplementation(() => new Promise((resolve, reject) => resolve(new Map([
+        ['reCaptcha.enabled', false]
+      ])))
+    )
+
+    req.query = {}
+    req.body.fields = {
+      comment: 'mock comment'
+    }
+    req.body.options = {
+      parent: 'mock parent'
+    }
+
+    const mockProcessData = {
+      fields: {}
+    }
+    mockProcessEntryFn.mockImplementation((fields, options) => new Promise((resolve, reject) => resolve(
+      mockProcessData
+    )))
+
+    expect.hasAssertions()
+    return process(req, res, next).then(() => {
+      expect(mockSetIpFn.mock.calls[0][0]).toEqual(req.headers['x-forwarded-for'])
+      expect(mockSetUserAgentFn.mock.calls[0][0]).toEqual(mockUserAgent)
+      expect(mockDecryptFn).toHaveBeenCalledTimes(0)
+      expect(mockErrorHandlerFn).toHaveBeenCalledTimes(0)
+      expect(mockProcessEntryFn).toHaveBeenCalledTimes(1)
+      expect(mockProcessEntryFn.mock.calls[0][0]).toBe(req.body.fields)
+      expect(mockProcessEntryFn.mock.calls[0][1]).toBe(req.body.options)
+      expect(mockSendResponseFn).toHaveBeenCalledTimes(1)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1]).toBe(mockProcessData)
+    })
+  })
+
+  test('entry processed if reCaptcha verification succeeds', () => {
+    mockGetSiteConfigFn.mockImplementation(() => new Promise((resolve, reject) => resolve(new Map([
+        ['reCaptcha.enabled', true],
+        ['reCaptcha.siteKey', mockReCaptchaSiteKey],
+        ['reCaptcha.secret', mockReCaptchaSecretDecrypted]
+      ])))
+    )
+
+    req.query = {}
+    req.body.fields = {
+      comment: 'mock comment'
+    }
+    req.body.options = {
+      parent: 'mock parent'
+    }
+    req.body.options.reCaptcha = {
+      siteKey: mockReCaptchaSiteKey, 
+      secret: mockReCaptchaSecret
+    }
+
+    mockDecryptFn.mockImplementation(() => mockReCaptchaSecretDecrypted)
+
+    mockReCaptchaVerifyFn.mockImplementation((req, callback) => {
+      callback(null)
+    })
+
+    const mockProcessData = {
+      fields: {}
+    }
+    mockProcessEntryFn.mockImplementation((fields, options) => new Promise((resolve, reject) => resolve(
+      mockProcessData
+    )))
+
+    expect.hasAssertions()
+    return process(req, res, next).then(() => {
+      expect(mockSetIpFn.mock.calls[0][0]).toEqual(req.headers['x-forwarded-for'])
+      expect(mockSetUserAgentFn.mock.calls[0][0]).toEqual(mockUserAgent)
+      expect(mockDecryptFn).toHaveBeenCalledTimes(1)
+      expect(mockErrorHandlerFn).toHaveBeenCalledTimes(0)
+      expect(mockProcessEntryFn).toHaveBeenCalledTimes(1)
+      expect(mockProcessEntryFn.mock.calls[0][0]).toBe(req.body.fields)
+      expect(mockProcessEntryFn.mock.calls[0][1]).toBe(req.body.options)
+      expect(mockSendResponseFn).toHaveBeenCalledTimes(1)
+      expect(mockSendResponseFn.mock.calls[0][0]).toBe(res)
+      expect(mockSendResponseFn.mock.calls[0][1]).toBe(mockProcessData)
+    })
+  })
+
 })

--- a/test/unit/controllers/sendResponse.test.js
+++ b/test/unit/controllers/sendResponse.test.js
@@ -1,0 +1,134 @@
+const { URL, URLSearchParams } = require('url')
+
+const mockHelpers = require('./../../helpers')
+
+let res
+
+const mockRedirect = 'https://example.com/redirect'
+const mockRedirectError = 'https://example.com/redirectError'
+
+let mockGetErrorCodeFn = jest.fn()
+let mockGetMessageFn = jest.fn()
+jest.mock('../../../lib/ErrorHandler', () => {
+  return {
+    getInstance: () => {
+      return {
+        getErrorCode: mockGetErrorCodeFn,
+        getMessage: mockGetMessageFn
+      }
+    }
+  }
+})
+
+// Instantiate the module being tested AFTER mocking dependendent modules above.
+const sendResponse = require('../../../controllers/sendResponse')
+
+beforeEach(() => {
+  res = mockHelpers.getMockResponse()
+})
+
+afterEach(() => {
+  mockGetErrorCodeFn.mockClear()
+  mockGetMessageFn.mockClear()
+})
+
+describe('Send response', () => {
+  test('redirect to success if no error, redirect supplied', () => {
+    const data = {
+      redirect: mockRedirect
+    }
+
+    expect.hasAssertions()
+    sendResponse(res, data)
+    expect(res.redirect.mock.calls[0][0]).toEqual(new URL(mockRedirect).toString())
+  })
+
+  test('redirect to success if secondary errors only, redirect supplied', () => {
+    const data = {
+      redirect: mockRedirect,
+      secondaryErrors: {
+      	mockError: 'mock secondary error'
+      }
+    }
+
+    expect.hasAssertions()
+    sendResponse(res, data)
+    expect(res.redirect.mock.calls[0][0]).toEqual(mockRedirect + '?mockError=mock+secondary+error')
+  })
+
+  test('redirect to error if error and redirect for error supplied', () => {
+    const data = {
+      redirectError: mockRedirectError,
+      err: 'mock error'
+    }
+
+    expect.hasAssertions()
+    sendResponse(res, data)
+    expect(res.redirect.mock.calls[0][0]).toEqual(new URL(mockRedirectError).toString())
+  })
+
+  test('respond with error if error key supplied', () => {
+    const data = {
+      err: {
+      	_smErrorCode: 'mock error key',
+      	data: 'mock error data'
+      }
+    }
+
+    const mockErrorCode = 'mock error code'
+    const mockErrorMessage = 'mock error message'
+
+    mockGetErrorCodeFn.mockImplementation((errorKey) => mockErrorCode)
+    mockGetMessageFn.mockImplementation((errorKey) => mockErrorMessage)
+
+    expect.hasAssertions()
+    sendResponse(res, data)
+    expect(mockGetErrorCodeFn).toHaveBeenCalledTimes(1)
+    expect(mockGetMessageFn).toHaveBeenCalledTimes(1)
+    expect(res.status.mock.calls[0][0]).toEqual(500)
+    expect(res.send.mock.calls[0][0].success).toEqual(false)
+    expect(res.send.mock.calls[0][0].message).toEqual(mockErrorMessage)
+    expect(res.send.mock.calls[0][0].data).toBe(data.err.data)
+    expect(res.send.mock.calls[0][0].rawError).toBe(data.err)
+    expect(res.send.mock.calls[0][0].errorCode).toEqual(mockErrorCode)
+  })
+
+  test('respond with raw error if no error key supplied', () => {
+    const data = {
+      err: {
+      	data: 'mock error data'
+      }
+    }
+
+    expect.hasAssertions()
+    sendResponse(res, data)
+    expect(mockGetErrorCodeFn).toHaveBeenCalledTimes(0)
+    expect(mockGetMessageFn).toHaveBeenCalledTimes(0)
+    expect(res.status.mock.calls[0][0]).toEqual(500)
+    expect(res.send.mock.calls[0][0].success).toEqual(false)
+    expect(res.send.mock.calls[0][0].message).toBeUndefined()
+    expect(res.send.mock.calls[0][0].data).toBeUndefined()
+    expect(res.send.mock.calls[0][0].rawError).toBe(data.err.toString())
+    expect(res.send.mock.calls[0][0].errorCode).toBeUndefined()
+  })
+
+  test('respond with success if no error supplied', () => {
+    const data = {
+      fields: {
+      	comment: 'mock comment'
+      },
+      secondaryErrors: {
+      	mockError: 'mock secondary error'
+      }
+    }
+
+    expect.hasAssertions()
+    sendResponse(res, data)
+    expect(mockGetErrorCodeFn).toHaveBeenCalledTimes(0)
+    expect(mockGetMessageFn).toHaveBeenCalledTimes(0)
+    expect(res.status.mock.calls[0][0]).toEqual(200)
+    expect(res.send.mock.calls[0][0].success).toEqual(true)
+    expect(res.send.mock.calls[0][0].fields).toBe(data.fields)
+    expect(res.send.mock.calls[0][0].secondaryErrors).toBe(data.secondaryErrors)
+  })
+})

--- a/test/unit/lib/Confirmation.test.js
+++ b/test/unit/lib/Confirmation.test.js
@@ -1,0 +1,291 @@
+const config = require('./../../../config')
+const mockHelpers = require('./../../helpers')
+
+const recipient = 'john.doe@example.com'
+
+let mockSubject
+let mockContent
+let mockSubjectError
+let mockContentError
+let mockData
+let mockCryptoPepper = 'mock crypto pepper'
+
+// Mock the readFile function within the native fs module, but leave every other function.
+jest.mock('fs', () => {
+  const fsOrig = require.requireActual('fs')
+  return {
+    ...fsOrig,
+    readFile: (path, options, callback) => {
+      // Only intercept requests for our subject and content templates.
+      if (path.endsWith('email-confirmation-subject.njk')) {
+        callback(mockSubjectError, mockSubject)
+      } else if (path.endsWith('email-confirmation-content.njk')) {
+        callback(mockContentError, mockContent)
+      } else {
+        return fsOrig.readFile(path, options, callback)
+      }
+    }
+  }
+})
+
+let mockEncryptFunc = jest.fn()
+jest.mock('./../../../lib/RSA', () => {
+  return {
+    encrypt: mockEncryptFunc
+  }
+})
+
+const Confirmation = require('./../../../lib/Confirmation')
+
+let mockMailAgent
+let mockSendFunc = jest.fn()
+
+beforeEach(() => {
+  config.set('cryptoPepper', mockCryptoPepper)
+
+  mockMailAgent = {
+    messages: jest.fn().mockImplementation(() => {
+      const result = {
+        send: mockSendFunc
+      }
+      return result
+    })
+  }
+
+  mockSubject = null
+  mockContent = null
+  mockSubjectError = null
+  mockContentError = null
+
+  mockData = {
+    data: {
+      siteName: 'Test blog'
+    },
+    fields: {
+      name: 'Eduardo Bouças',
+      email: 'mail@eduardoboucas.com'
+    },
+    extendedFields: {
+      _id: '70c33c00-17b3-11eb-b910-2f4fc1bf5873'
+    },
+    options: {
+      origin: 'https://eduardoboucas.com/an-awesome-post-about-staticman', 
+      parent: 'an-awesome-post-about-staticman',
+      parentName: 'An Awesome Post About Staticman',
+      subscribeConfirmRedirect: 'mock subscribe confirm redirect',
+      subscribeConfirmRedirectError: 'mock subscribe confirm redirect error',
+      subscribeConsentUrl: 'mock subscribe consent url',
+      subscribeConsentContext: 'mock subscribe consent context',
+      subscribeConsentText: 'mock subscribe consent text'
+    } 
+  }
+})
+
+afterEach(() => {
+  mockMailAgent.messages.mockClear()
+  mockSendFunc.mockClear()
+  mockEncryptFunc.mockClear()
+})
+
+describe('Confirmation interface', () => {
+  describe('send', () => {
+    test('sends confirmation email with customized subject and content', async () => {
+      const confirmation = new Confirmation(mockMailAgent)
+      
+      mockSendFunc.mockImplementation( (payload, callback) => callback(null, 'success') )
+
+      mockSubject = 'Mock subscription confirmation for {{ data.siteName }}'
+      mockContent = 'Mock subscription confirmation email explanation to receive notifications for {{ options.origin }}. ' + 
+        '<!--confirmTextStart-->Mock confirm text!<!--confirmTextEnd-->'
+
+      expect.hasAssertions()
+      await confirmation.send(recipient, mockData.fields, mockData.extendedFields, mockData.options, mockData.data).then(response => {
+        expect(mockSendFunc).toHaveBeenCalledTimes(1)
+        expect(mockSendFunc.mock.calls[0][0].from.includes(config.get('email.fromAddress'))).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].to).toBe(recipient)
+        expect(mockSendFunc.mock.calls[0][0].subject).toBe('Mock subscription confirmation for ' + mockData.data.siteName)
+        expect(mockSendFunc.mock.calls[0][0].html).toContain(
+          'Mock subscription confirmation email explanation to receive notifications for ' + mockData.options.origin + '.')
+        expect(mockSendFunc.mock.calls[0][0]['h:Reply-To']).toBe(mockSendFunc.mock.calls[0][0].from)
+
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).pepper).toEqual(mockCryptoPepper)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscriberEmailAddress).toEqual(recipient)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).parent).toEqual(mockData.options.parent)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).parentName).toEqual(mockData.options.parentName)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConfirmContext).toEqual(
+          'Email "Mock subscription confirmation for ' + mockData.data.siteName + '"')
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConfirmText).toEqual('Mock confirm text!')
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConfirmRedirect).toEqual(mockData.options.subscribeConfirmRedirect)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConfirmRedirectError).toEqual(mockData.options.subscribeConfirmRedirectError)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConsentDate).toBeDefined()
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConsentUrl).toEqual(mockData.options.subscribeConsentUrl)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConsentContext).toEqual(mockData.options.subscribeConsentContext)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConsentText).toEqual(mockData.options.subscribeConsentText)
+      })
+    })
+
+    test('sends confirmation email with customized subject and content, use consent data overrides/defaults', async () => {
+      const confirmation = new Confirmation(mockMailAgent)
+      
+      mockSendFunc.mockImplementation( (payload, callback) => callback(null, 'success') )
+
+      mockSubject = 'Mock subscription confirmation for {{ data.siteName }}'
+      mockContent = 'Mock subscription confirmation email explanation to receive notifications for {{ options.origin }}. ' + 
+        '<!--confirmTextStart-->Mock confirm text!<!--confirmTextEnd-->'
+
+      mockData.options.subscribeConsentDate = 'supplied consent date'
+      delete mockData.options.subscribeConsentUrl
+      delete mockData.options.subscribeConsentContext
+
+      expect.hasAssertions()
+      await confirmation.send(recipient, mockData.fields, mockData.extendedFields, mockData.options, mockData.data).then(response => {
+        expect(mockSendFunc).toHaveBeenCalledTimes(1)
+        expect(mockSendFunc.mock.calls[0][0].from.includes(config.get('email.fromAddress'))).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].to).toBe(recipient)
+        expect(mockSendFunc.mock.calls[0][0].subject).toBe('Mock subscription confirmation for ' + mockData.data.siteName)
+        expect(mockSendFunc.mock.calls[0][0].html).toContain(
+          'Mock subscription confirmation email explanation to receive notifications for ' + mockData.options.origin + '.')
+        expect(mockSendFunc.mock.calls[0][0]['h:Reply-To']).toBe(mockSendFunc.mock.calls[0][0].from)
+
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).pepper).toEqual(mockCryptoPepper)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscriberEmailAddress).toEqual(recipient)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).parent).toEqual(mockData.options.parent)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).parentName).toEqual(mockData.options.parentName)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConfirmContext).toEqual(
+          'Email "Mock subscription confirmation for ' + mockData.data.siteName + '"')
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConfirmText).toEqual('Mock confirm text!')
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConfirmRedirect).toEqual(mockData.options.subscribeConfirmRedirect)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConfirmRedirectError).toEqual(mockData.options.subscribeConfirmRedirectError)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConsentDate).toEqual(mockData.options.subscribeConsentDate)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConsentUrl).toEqual(mockData.options.origin)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConsentContext).toEqual(mockData.options.parentName)
+        expect(JSON.parse(mockEncryptFunc.mock.calls[0][0]).subscribeConsentText).toEqual(mockData.options.subscribeConsentText)
+      })
+    })
+
+    test('sends confirmation email with default subject and content if error raised reading templates', async () => {
+      const confirmation = new Confirmation(mockMailAgent)
+      
+      mockSendFunc.mockImplementation( (payload, callback) => callback(null, 'success') )
+
+      // Force errors when trying to read the subject and content templates.
+      mockSubjectError = 'subject readFile error'
+      mockContentError = 'content readFile error'
+
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect.hasAssertions()
+      await confirmation.send(recipient, mockData.fields, mockData.extendedFields, mockData.options, mockData.data).then(response => {
+        expect(mockSendFunc).toHaveBeenCalledTimes(1)
+        expect(mockSendFunc.mock.calls[0][0].from.includes(config.get('email.fromAddress'))).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].to).toBe(recipient)
+        // Expect that the default email subject will be used.
+        expect(mockSendFunc.mock.calls[0][0].subject).toBe('Please confirm your subscription to ' + mockData.data.siteName)
+        // Expect that the default email content will be used.
+        expect(mockSendFunc.mock.calls[0][0].html.includes(
+          'You have requested to be notified every time a new comment is added to <a href="' + mockData.options.origin + '">' + 
+          mockData.options.origin + '</a>.')).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].html.includes(
+          '<!--confirmTextStart-->Please confirm your subscription request by clicking this link:<!--confirmTextEnd-->')).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0]['h:Reply-To']).toBe(mockSendFunc.mock.calls[0][0].from)
+
+        // Restore console.error
+        consoleSpy.mockRestore()
+      })
+    })
+
+    test('sends confirmation email with default subject and content if templates empty', async () => {
+      const confirmation = new Confirmation(mockMailAgent)
+      
+      mockSendFunc.mockImplementation( (payload, callback) => callback(null, 'success') )
+
+      // Force empty templates.
+      mockSubject = '    '
+      mockContent = ' '
+
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect.hasAssertions()
+      await confirmation.send(recipient, mockData.fields, mockData.extendedFields, mockData.options, mockData.data).then(response => {
+        expect(mockSendFunc).toHaveBeenCalledTimes(1)
+        expect(mockSendFunc.mock.calls[0][0].from.includes(config.get('email.fromAddress'))).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].to).toBe(recipient)
+        // Expect that the default email subject will be used.
+        expect(mockSendFunc.mock.calls[0][0].subject).toBe('Please confirm your subscription to ' + mockData.data.siteName)
+        // Expect that the default email content will be used.
+        expect(mockSendFunc.mock.calls[0][0].html.includes(
+          'You have requested to be notified every time a new comment is added to <a href="' + mockData.options.origin + '">' + 
+          mockData.options.origin + '</a>.')).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].html.includes(
+          '<!--confirmTextStart-->Please confirm your subscription request by clicking this link:<!--confirmTextEnd-->')).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0]['h:Reply-To']).toBe(mockSendFunc.mock.calls[0][0].from)
+
+        // Restore console.error
+        consoleSpy.mockRestore()
+      })
+    })
+
+    test('sends confirmation email with default subject and content if templates render to empty', async () => {
+      const confirmation = new Confirmation(mockMailAgent)
+      
+      mockSendFunc.mockImplementation( (payload, callback) => callback(null, 'success') )
+
+      // Force contents of rendered templates to be empty.
+      mockSubject = '  {{ options.foo }}     '
+      mockContent = ' {{ fields.bar }} {{ fields.baz }}'
+
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect.hasAssertions()
+      await confirmation.send(recipient, mockData.fields, mockData.extendedFields, mockData.options, mockData.data).then(response => {
+        expect(mockSendFunc).toHaveBeenCalledTimes(1)
+        expect(mockSendFunc.mock.calls[0][0].from.includes(config.get('email.fromAddress'))).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].to).toBe(recipient)
+        // Expect that the default email subject will be used.
+        expect(mockSendFunc.mock.calls[0][0].subject).toBe('Please confirm your subscription to ' + mockData.data.siteName)
+        // Expect that the default email content will be used.
+        expect(mockSendFunc.mock.calls[0][0].html.includes(
+          'You have requested to be notified every time a new comment is added to <a href="' + mockData.options.origin + '">' + 
+          mockData.options.origin + '</a>.')).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].html.includes(
+          '<!--confirmTextStart-->Please confirm your subscription request by clicking this link:<!--confirmTextEnd-->')).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0]['h:Reply-To']).toBe(mockSendFunc.mock.calls[0][0].from)
+
+        // Restore console.error
+        consoleSpy.mockRestore()
+      })
+    })
+
+    test('send error handled', async () => {
+      const confirmation = new Confirmation(mockMailAgent)
+      
+      // Mock that the message send errors.
+      mockSendFunc.mockImplementation( (payload, callback) => callback(
+        {statusCode: 500, message: 'message send failure'}, null) )
+
+      mockSubject = 'Test subject'
+      mockContent = 'Test content'
+
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      expect.hasAssertions()
+      await confirmation.send(recipient, mockData.fields, mockData.extendedFields, mockData.options, mockData.data).catch(error => {
+        expect(error.message).toBe('message send failure')
+
+        expect(mockSendFunc).toHaveBeenCalledTimes(1)
+        expect(mockSendFunc.mock.calls[0][0].from.includes(config.get('email.fromAddress'))).toBe(true)
+        expect(mockSendFunc.mock.calls[0][0].to).toBe(recipient)
+        expect(mockSendFunc.mock.calls[0][0].subject).toBe(mockSubject)
+        expect(mockSendFunc.mock.calls[0][0].html).toBe(mockContent)
+        expect(mockSendFunc.mock.calls[0][0]['h:Reply-To']).toBe(mockSendFunc.mock.calls[0][0].from)
+
+        // Restore console.error
+        consoleSpy.mockRestore()
+      })
+    })
+  })
+})

--- a/test/unit/lib/Staticman.test.js
+++ b/test/unit/lib/Staticman.test.js
@@ -1379,7 +1379,7 @@ describe('Staticman interface', () => {
       })
 
       // Suppress any calls to console.error - to keep test output clean.
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
       return staticman.processEntry(
         mockHelpers.getFields(),
@@ -1390,7 +1390,7 @@ describe('Staticman interface', () => {
         })
 
         // Restore console.error
-        consoleSpy.mockRestore();
+        consoleSpy.mockRestore()
       })
     })
 
@@ -1407,7 +1407,7 @@ describe('Staticman interface', () => {
       staticman.siteConfig = mockConfig
 
       // Suppress any calls to console.error - to keep test output clean.
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
       return staticman.processEntry(
         mockHelpers.getFields(),
@@ -1419,7 +1419,7 @@ describe('Staticman interface', () => {
         })
 
         // Restore console.error
-        consoleSpy.mockRestore();
+        consoleSpy.mockRestore()
       })
     })
 
@@ -1444,7 +1444,7 @@ describe('Staticman interface', () => {
         })
 
         // Suppress any calls to console.error - to keep test output clean.
-        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
         return staticman.processEntry(
           mockHelpers.getFields(),
@@ -1458,7 +1458,7 @@ describe('Staticman interface', () => {
           })
 
           // Restore console.error
-          consoleSpy.mockRestore();
+          consoleSpy.mockRestore()
         })
       }
     )
@@ -1516,7 +1516,7 @@ describe('Staticman interface', () => {
       })
     })
 
-    test('subscribes the user to notifications', async () => {
+    test('subscribes the user to notifications if subscribe option supplied and no consent model', async () => {
       const mockSubscriptionSet = jest.fn(() => Promise.resolve(true))
 
       jest.mock('./../../../lib/SubscriptionsManager', () => {
@@ -1550,6 +1550,137 @@ describe('Staticman interface', () => {
       ).then(response => {
         expect(mockSubscriptionSet.mock.calls[0][0]).toEqual(options)
         expect(mockSubscriptionSet.mock.calls[0][1]).toBe(mockHelpers.getFields().email)
+        expect(response.secondaryErrors).toBeUndefined()
+      })
+    })
+
+    test('returns error if subscription fails when subscribe option supplied and no consent model', async () => {
+      const mockSubscriptionSet = jest.fn(() => Promise.reject( { message: 'mock error' } ))
+
+      jest.mock('./../../../lib/SubscriptionsManager', () => {
+        return jest.fn(() => ({
+          send: jest.fn(),
+          set: mockSubscriptionSet
+        }))
+      })
+
+      const Staticman = require('./../../../lib/Staticman')
+      const staticman = await new Staticman(mockParameters)
+      const fields = mockHelpers.getFields()
+      const options = {
+        parent: '1a2b3c4d5e6f',
+        subscribe: 'email'
+      }
+
+      mockConfig.set('allowedFields', Object.keys(fields))
+      mockConfig.set('moderation', false)
+      mockConfig.set('notifications.enabled', true)
+
+      staticman.siteConfig = mockConfig
+      staticman._checkForSpam = () => Promise.resolve(fields)
+      staticman.git.writeFile = jest.fn(() => {
+        return Promise.resolve()
+      })
+
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      return staticman.processEntry(
+        fields,
+        options
+      ).then(response => {
+        expect(mockSubscriptionSet.mock.calls[0][0]).toEqual(options)
+        expect(mockSubscriptionSet.mock.calls[0][1]).toBe(mockHelpers.getFields().email)
+        expect(response.secondaryErrors.subscribeError).toEqual(true)
+        expect(response.secondaryErrors.subscribeConfirmError).toEqual(false)
+
+        // Restore console.error
+        consoleSpy.mockRestore()
+      })
+    })
+
+    test('sends confirmation for notifications if subscribe option supplied and double consent model', async () => {
+      const mockSendConfirmFn = jest.fn(() => Promise.resolve(true))
+
+      jest.mock('./../../../lib/SubscriptionsManager', () => {
+        return jest.fn(() => ({
+          send: jest.fn(),
+          sendConfirm: mockSendConfirmFn
+        }))
+      })
+
+      const Staticman = require('./../../../lib/Staticman')
+      const staticman = await new Staticman(mockParameters)
+      const fields = mockHelpers.getFields()
+      const options = {
+        parent: '1a2b3c4d5e6f',
+        subscribe: 'email'
+      }
+
+      mockConfig.set('allowedFields', Object.keys(fields))
+      mockConfig.set('moderation', false)
+      mockConfig.set('notifications.enabled', true)
+      mockConfig.set('notifications.consentModel', 'double')
+
+      staticman.siteConfig = mockConfig
+      staticman._checkForSpam = () => Promise.resolve(fields)
+      staticman.git.writeFile = jest.fn(() => {
+        return Promise.resolve()
+      })
+
+      return staticman.processEntry(
+        fields,
+        options
+      ).then(response => {
+        expect(mockSendConfirmFn.mock.calls[0][0]).toBe(mockHelpers.getFields().email)
+        expect(mockSendConfirmFn.mock.calls[0][1]).toEqual(fields)
+        expect(response.secondaryErrors).toBeUndefined()
+      })
+    })
+
+    test('returns error if confirmation send fails when subscribe option supplied and double consent model', async () => {
+      const mockSendConfirmFn = jest.fn(() => Promise.reject( { message: 'mock error' } ))
+
+      jest.mock('./../../../lib/SubscriptionsManager', () => {
+        return jest.fn(() => ({
+          send: jest.fn(),
+          sendConfirm: mockSendConfirmFn
+        }))
+      })
+
+      const Staticman = require('./../../../lib/Staticman')
+      const staticman = await new Staticman(mockParameters)
+      const fields = mockHelpers.getFields()
+      const options = {
+        parent: '1a2b3c4d5e6f',
+        subscribe: 'email'
+      }
+
+      mockConfig.set('allowedFields', Object.keys(fields))
+      mockConfig.set('moderation', false)
+      mockConfig.set('notifications.enabled', true)
+      mockConfig.set('notifications.consentModel', 'double')
+
+      staticman.siteConfig = mockConfig
+      staticman._checkForSpam = () => Promise.resolve(fields)
+      staticman.git.writeFile = jest.fn(() => {
+        return Promise.resolve()
+      })
+
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+      return staticman.processEntry(
+        fields,
+        options
+      ).then(response => {
+        expect(mockSendConfirmFn.mock.calls[0][0]).toBe(mockHelpers.getFields().email)
+        expect(mockSendConfirmFn.mock.calls[0][1]).toEqual(fields)
+        expect(response.secondaryErrors.subscribeError).toEqual(false)
+        expect(response.secondaryErrors.subscribeConfirmError).toEqual(true)
+
+        // Restore console.error
+        consoleSpy.mockRestore()
       })
     })
 
@@ -1708,7 +1839,7 @@ describe('Staticman interface', () => {
     })
 
     describe('`processMerge()`', () => {
-      test('subscribes the user to notifications', async () => {
+      test('sends notification emails', async () => {
         const mockSubscriptionSend = jest.fn()
 
         jest.mock('./../../../lib/SubscriptionsManager', () => {
@@ -1746,5 +1877,34 @@ describe('Staticman interface', () => {
         })
       })
     })
+
+    describe('`createSubscription()`', () => {
+      test('subscribes a user to notification emails', async () => {
+        const mockSetFn = jest.fn()
+
+        jest.mock('./../../../lib/SubscriptionsManager', () => {
+          return jest.fn(() => ({
+            set: mockSetFn
+          }))
+        })
+
+        const Staticman = require('./../../../lib/Staticman')
+        const staticman = await new Staticman(mockParameters)
+
+        const data = {
+          subscriberEmailAddress: 'mock email address'
+        }
+
+        mockConfig.set('notifications.enabled', true)
+        staticman.siteConfig = mockConfig
+
+        expect.hasAssertions()
+        return staticman.createSubscription(data).then(response => {
+          expect(mockSetFn.mock.calls[0][0]).toBe(data)
+          expect(mockSetFn.mock.calls[0][1]).toEqual(data.subscriberEmailAddress)
+        })
+      })
+    })
+
   })
 })

--- a/test/unit/lib/Staticman.test.js
+++ b/test/unit/lib/Staticman.test.js
@@ -1378,6 +1378,9 @@ describe('Staticman interface', () => {
         return Promise.reject(errorHandler('IS_SPAM'))
       })
 
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
       return staticman.processEntry(
         mockHelpers.getFields(),
         {}
@@ -1385,6 +1388,9 @@ describe('Staticman interface', () => {
         expect(err).toEqual({
           _smErrorCode: 'IS_SPAM'
         })
+
+        // Restore console.error
+        consoleSpy.mockRestore();
       })
     })
 
@@ -1400,6 +1406,9 @@ describe('Staticman interface', () => {
       staticman._checkForSpam = () => Promise.resolve(fields)
       staticman.siteConfig = mockConfig
 
+      // Suppress any calls to console.error - to keep test output clean.
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
       return staticman.processEntry(
         mockHelpers.getFields(),
         {}
@@ -1408,6 +1417,9 @@ describe('Staticman interface', () => {
           _smErrorCode: 'INVALID_FIELDS',
           data: ['someField1']
         })
+
+        // Restore console.error
+        consoleSpy.mockRestore();
       })
     })
 
@@ -1431,6 +1443,9 @@ describe('Staticman interface', () => {
           return Promise.reject(errorHandler('INVALID_FORMAT'))
         })
 
+        // Suppress any calls to console.error - to keep test output clean.
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
         return staticman.processEntry(
           mockHelpers.getFields(),
           {}
@@ -1441,6 +1456,9 @@ describe('Staticman interface', () => {
           expect(err).toEqual({
             _smErrorCode: 'INVALID_FORMAT'
           })
+
+          // Restore console.error
+          consoleSpy.mockRestore();
         })
       }
     )

--- a/test/unit/lib/SubscriptionsManager.test.js
+++ b/test/unit/lib/SubscriptionsManager.test.js
@@ -54,6 +54,8 @@ beforeEach(() => {
 	  parent: 'an-awesome-post-about-staticman',
     origin: 'http://blog.example.com'
   }
+
+  siteConfig = mockHelpers.getConfig()
 })
 
 afterEach(() => {
@@ -76,7 +78,7 @@ describe('SubscriptionsManager', () => {
       mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
 
       expect.hasAssertions()
-      await subscriptionsMgr.set(options, emailAddr).then(response => {
+      await subscriptionsMgr.set(options, emailAddr, siteConfig).then(response => {
         expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
         expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
         expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
@@ -101,7 +103,7 @@ describe('SubscriptionsManager', () => {
       options.parentName = 'Post an-awesome-post-about-staticman'
 
       expect.hasAssertions()
-      await subscriptionsMgr.set(options, emailAddr).then(response => {
+      await subscriptionsMgr.set(options, emailAddr, siteConfig).then(response => {
         expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
         expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
         expect(mockListsCreateFunc).toHaveBeenCalledTimes(1)
@@ -126,7 +128,7 @@ describe('SubscriptionsManager', () => {
       mockListsMembersCreateFunc.mockImplementation( (createData, callback) => callback(null, 'success'))
 
       expect.hasAssertions()
-      await subscriptionsMgr.set(options, emailAddr).then(response => {
+      await subscriptionsMgr.set(options, emailAddr, siteConfig).then(response => {
         expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
         expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
         // Assert that list not created.
@@ -145,7 +147,7 @@ describe('SubscriptionsManager', () => {
         callback({statusCode: 500, message: 'list lookup failure'}, null) )
 
       expect.hasAssertions()
-      await subscriptionsMgr.set(options, emailAddr).catch(error => {
+      await subscriptionsMgr.set(options, emailAddr, siteConfig).catch(error => {
         expect(error.message).toBe('list lookup failure')
         expect(mockMailAgent.lists).toHaveBeenCalledTimes(1)
         expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
@@ -163,7 +165,7 @@ describe('SubscriptionsManager', () => {
         callback({statusCode: 500, message: 'list create failure'}, null) )
 
       expect.hasAssertions()
-      await subscriptionsMgr.set(options, emailAddr).catch(error => {
+      await subscriptionsMgr.set(options, emailAddr, siteConfig).catch(error => {
         expect(error.message).toBe('list create failure')
         expect(mockMailAgent.lists).toHaveBeenCalledTimes(2)
         expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
@@ -182,7 +184,7 @@ describe('SubscriptionsManager', () => {
         callback({statusCode: 500, message: 'member create failure'}, null) )
 
       expect.hasAssertions()
-      await subscriptionsMgr.set(options, emailAddr).catch(error => {
+      await subscriptionsMgr.set(options, emailAddr, siteConfig).catch(error => {
         expect(error.message).toBe('member create failure')
         expect(mockMailAgent.lists).toHaveBeenCalledTimes(3)
         expect(mockListsInfoFunc).toHaveBeenCalledTimes(1)
@@ -219,8 +221,6 @@ describe('SubscriptionsManager', () => {
         _id: '70c33c00-17b3-11eb-b910-2f4fc1bf5873'
       }
       extendedFields = Object.assign({}, fields)
-
-      siteConfig = mockHelpers.getConfig()
     })
 
     test('sends notification email to mailing list', async () => {


### PR DESCRIPTION
This addresses issue eduardoboucas#277 - "feature request: GDPR compliance and double opt-in for notifications".

A new `consentModel` property has been added to the YAML config schema that allows single opt-in or double opt-in email confirmation models to be enabled (with the default being none). Corresponding support has been added for a number of new audit-centric options to be submitted in the comment payload. 

- `subscribeConsentUrl` - See below for more info.
- `subscribeConsentContext` - See below for more info.
- `subscribeConsentText` - See below for more info.
- `subscribeConfirmUrl` - The base URL for the `confirm` endpoint. See below for more info. Applies for double opt-in only.
- `subscribeConfirmRedirect` - The URL to which the subscriber will be redirected upon confirming their subscription, if successful. Applies for double opt-in only.
- `subscribeConfirmRedirectError` - The URL to which the subscriber will be redirected if a fatal error is raised when confirming their subscription. Applies for double opt-in only.

Support has been added in the `SubscriptionsManager` module that, when subscribing a user, records both single opt-in ("consent") audit fields and double opt-in ("confirm") audit fields in a subscriber's mailing list entry in Mailgun. The fields are as follows: 

- `subscribeConsentDate` - The date when consent was given. Applies for both single and double opt-in.
- `subscribeConsentUrl` - The URL from where consent was given. Applies for both single and double opt-in.
- `subscribeConsentContext` - A text description of where consent was given. Applies for both single and double opt-in.
- `subscribeConsentText` - The actual textual "call-to-action" displayed when consent was given. Applies for both single and double opt-in.
- `subscribeConfirmDate` - The date when consent was confirmed. Applies for double opt-in only.
- `subscribeConfirmContext` - A text description of where consent was confirmed. Applies for double opt-in only.
- `subscribeConfirmText` - The actual textual "call-to-action" displayed when consent was confirmed. Applies for double opt-in only.

A new `Confirmation` module has been added which handles building and sending confirmation emails. It mimics the existing `Notification` module (which handles building and sending notification emails). Confirmation emails are built to contain a link with an encrypted querystring which contains all of the data about the potential subscriber, including email address, what they are subscribing to, etc. This allows us to avoid persisting any data about the user until they actually confirm. Customization of the confirmation email subject and content is allowed-for via [Nunjucks](https://mozilla.github.io/nunjucks/) template files.

A new `confirm` endpoint has been added. It is meant to receive requests triggered by users clicking confirmation links in emails sent to confirm that the user wants to subscribe to notification emails (sent whenever new comments are added to a post, parent comment, etc.).

Support has been added to the JSON config schema for a cryptographic pepper - `cryptoPepper`. This is meant to prevent attackers from creating their own valid encrypted strings and subscribing whoever they want to notifications.

The "sendResponse" logic has been extracted out of the `process` controller (into a new `sendResponse` module) so that it can be re-used (initially, by the new `confirmSubscription` controller). Functionality has been added to this `sendResponse` module that allows for secondary errors to be communicated back in the response, in both a redirect response and a direct response.