### PR TITLE
Configure the webhook secret per-repo instead of globally

### DIFF
--- a/config.js
+++ b/config.js
@@ -90,12 +90,6 @@ const schema = {
     default: null,
     env: 'GITHUB_TOKEN'
   },
-  githubWebhookSecret: {
-    doc: 'Token to verify that webhook requests are from GitHub',
-    format: String,
-    default: null,
-    env: 'GITHUB_WEBHOOK_SECRET'
-  },
   gitlabAccessTokenUri: {
     doc: 'URI for the GitLab authentication provider.',
     format: String,
@@ -113,12 +107,6 @@ const schema = {
     format: String,
     default: null,
     env: 'GITLAB_TOKEN'
-  },
-  gitlabWebhookSecret: {
-    doc: 'Token to verify that webhook requests are from GitLab',
-    format: String,
-    default: null,
-    env: 'GITLAB_WEBHOOK_SECRET'
   },
   port: {
     doc: 'The port to bind the application to.',

--- a/server.js
+++ b/server.js
@@ -97,10 +97,10 @@ class StaticmanAPI {
 
     this.server.post(
       /*
-       * Make the service, username, repository, and branch parameters optional in order to
+       * Make the service, username, repository, etc. parameters optional in order to
        * maintain backwards-compatibility with v1 of the endpoint, which assumed GitHub.
        */
-      '/v:version/webhook/:service?/:username?/:repository?/:branch?/',
+      '/v:version/webhook/:service?/:username?/:repository?/:branch?/:property?',
       this.bruteforce.prevent,
       this.requireApiVersion([1, 3]),
       /*

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -107,6 +107,11 @@ const schema = {
       default: false
     }
   },
+  githubWebhookSecret: {
+    doc: 'Token to verify that webhook requests are from GitHub',
+    format: 'EncryptedString',
+    default: null
+  },
   gitlabAuth: {
     clientId: {
       doc: 'The client ID to the GitLab Application used for GitLab OAuth.',
@@ -123,6 +128,11 @@ const schema = {
       format: String,
       default: ''
     }
+  },
+  gitlabWebhookSecret: {
+    doc: 'Token to verify that webhook requests are from GitLab',
+    format: 'EncryptedString',
+    default: null
   },
   moderation: {
     doc: 'When set to `true`, a pull request with the data files will be created to allow site administrators to approve or reject an entry. Otherwise, entries will be pushed to `branch` immediately.',


### PR DESCRIPTION
Configure the webhook secret on a per-repo basis instead of globally per Staticman install. This allows for one Staticman install to be shared by multiple git repositories. This change requires the webhook secret to be encrypted, as it could be housed in a publicly-accessible repository. This also required adding a `property` parameter to the `webhook` endpoint so we can retrieve the repo-resident site config.