### PR TITLE
Allow for customizing the size of generated comment IDs

### DIFF
--- a/config.js
+++ b/config.js
@@ -135,6 +135,18 @@ const schema = {
       default: null,
       env: 'SLACK_WEBHOOK'
     }
+  },
+  commentIdGenerator: {
+    doc: 'The scheme to use for generating IDs for comments. More info about nanoid - https://github.com/ai/nanoid',
+    format: ['uuid', 'nanoid', 'nanoid-lowercase'],
+    default: 'uuid',
+    env: 'COMMENT_ID_GENERATOR'
+  },
+  commentIdLength: {
+    doc: 'The desired length of generated comment IDs. Only applicable when commentIdGenerator is set to "nanoid" or "nanoid-lowercase"',
+    format: Number,
+    default: 21,
+    env: 'COMMENT_ID_LENGTH'
   }
 }
 

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -14,6 +14,8 @@ const SubscriptionsManager = require('./SubscriptionsManager')
 const Transforms = require('./Transforms')
 const uuidv1 = require('uuid/v1')
 const yaml = require('js-yaml')
+const en = require('nanoid-good/locale/en')
+const nanoid = require('nanoid-good').customAlphabet(en)
 
 class Staticman {
   constructor (parameters) {
@@ -36,14 +38,27 @@ class Staticman {
         version
       })
 
-      // Generate unique id
-      this.uid = uuidv1()
+      this._generateCommentId()
 
       this.rsa = new NodeRSA()
       this.rsa.importKey(config.get('rsaPrivateKey'), 'private')
 
       return this
     })()
+  }
+
+  // Generate unique id
+  _generateCommentId () {
+    const commentIdGenerator = config.get('commentIdGenerator')
+    if (commentIdGenerator === 'nanoid') {
+      const commentIdLength = config.get('commentIdLength')
+      this.uid = nanoid(commentIdLength)
+    } else if (commentIdGenerator === 'nanoid-lowercase') {
+      const commentIdLength = config.get('commentIdLength')
+      this.uid = nanoid('0123456789_abcdefghijklmnopqrstuvwxyz-', commentIdLength)()
+    } else {
+      this.uid = uuidv1()
+    }
   }
 
   _applyInternalFields (data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2389,14 +2389,6 @@
         "underscore": "~1.5.1"
       }
     },
-    "express-github-webhook": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/express-github-webhook/-/express-github-webhook-1.0.6.tgz",
-      "integrity": "sha1-qYDKCriLjL2ke5Sh6RjD8KaPTK0=",
-      "requires": {
-        "buffer-equal-constant-time": "^1.0.1"
-      }
-    },
     "express-recaptcha": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/express-recaptcha/-/express-recaptcha-2.3.0.tgz",
@@ -5923,6 +5915,20 @@
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw=="
+    },
+    "nanoid-good": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nanoid-good/-/nanoid-good-3.1.0.tgz",
+      "integrity": "sha512-gG9D+AVHAZ+t2mAk3sw+Bx08VzOBc8fc+JylIzCLbEoRYakvQK9RiI3U+bXjdlMc5Ec4W9zUQsZZKngjifv7Vw==",
+      "requires": {
+        "nanoid": "^3.1.2",
+        "naughty-words": "^1.2.0"
+      }
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -5946,6 +5952,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "naughty-words": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/naughty-words/-/naughty-words-1.2.0.tgz",
+      "integrity": "sha512-0iadX6fN+3NsfvIRtWmmpEX9VsoIQ6n9FwyIxmew9w5yzFNqMgs/Ky0eAC/z5xXSHtqlVoByiovdROikwH9SXQ=="
     },
     "ncp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "body-parser": "^1.17.x",
     "bunyan-slack": "0.0.10",
     "convict": "^4.3.0",
+    "cors": "^2.8.5",
     "express": "^4.14.0",
     "express-brute": "^0.6.0",
     "express-recaptcha": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "body-parser": "^1.17.x",
     "bunyan-slack": "0.0.10",
     "convict": "^4.3.0",
-    "cors": "^2.8.5",
     "express": "^4.14.0",
     "express-brute": "^0.6.0",
     "express-recaptcha": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "markdown-table": "^1.0.0",
     "md5": "^2.1.0",
     "moment": "^2.18.1",
+    "nanoid": "^3.1.20",
+    "nanoid-good": "^3.1.0",
     "node-rsa": "^0.4.2",
     "nodemon": "^1.19.4",
     "nunjucks": "^3.2.2",

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@ const config = require('./config')
 const express = require('express')
 const ExpressBrute = require('express-brute')
 const objectPath = require('object-path')
-const cors = require('cors')
 
 class StaticmanAPI {
   constructor () {
@@ -36,19 +35,12 @@ class StaticmanAPI {
   }
 
   initialiseCORS () {
-    console.log('in initialiseCORS');
-    this.corsOptions = {
-      origin: [/http[s]?:\/\/localhost:?\d*/, /http[s]?:\/\/10.0.2.2:?\d*/], 
-      //origin: /example\.com$/, 
-      allowedHeaders: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept']
-    }
+    this.server.use((req, res, next) => {
+      res.header('Access-Control-Allow-Origin', '*')
+      res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
 
-    // this.server.use((req, res, next) => {
-    //   res.header('Access-Control-Allow-Origin', '*')
-    //   res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
-
-    //   next()
-    // })
+      next()
+    })
   }
 
   initialiseRoutes () {
@@ -56,7 +48,6 @@ class StaticmanAPI {
     this.server.get(
       '/v:version/connect/:username/:repository',
       this.bruteforce.prevent,
-      cors(this.corsOptions), 
       this.requireApiVersion([1, 2]),
       this.controllers.connect
     )
@@ -65,7 +56,6 @@ class StaticmanAPI {
     this.server.post(
       '/v:version/entry/:username/:repository/:branch',
       this.bruteforce.prevent,
-      cors(this.corsOptions), 
       this.requireApiVersion([1, 2]),
       this.requireParams(['fields']),
       this.controllers.process
@@ -74,7 +64,6 @@ class StaticmanAPI {
     this.server.post(
       '/v:version/entry/:username/:repository/:branch/:property',
       this.bruteforce.prevent,
-      cors(this.corsOptions), 
       this.requireApiVersion([2]),
       this.requireParams(['fields']),
       this.controllers.process
@@ -83,7 +72,6 @@ class StaticmanAPI {
     this.server.post(
       '/v:version/entry/:service/:username/:repository/:branch/:property',
       this.bruteforce.prevent,
-      cors(this.corsOptions), 
       this.requireApiVersion([3]),
       this.requireService(['github', 'gitlab']),
       this.requireParams(['fields']),
@@ -94,7 +82,6 @@ class StaticmanAPI {
     this.server.get(
       '/v:version/encrypt/:text',
       this.bruteforce.prevent,
-      cors(this.corsOptions), 
       this.requireApiVersion([2, 3]),
       this.controllers.encrypt
     )
@@ -103,7 +90,6 @@ class StaticmanAPI {
     this.server.get(
       '/v:version/auth/:service/:username/:repository/:branch/:property',
       this.bruteforce.prevent,
-      cors(this.corsOptions), 
       this.requireApiVersion([2, 3]),
       this.requireService(['github', 'gitlab']),
       this.controllers.auth

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const config = require('./config')
 const express = require('express')
 const ExpressBrute = require('express-brute')
 const objectPath = require('object-path')
+const cors = require('cors')
 
 class StaticmanAPI {
   constructor () {
@@ -35,12 +36,19 @@ class StaticmanAPI {
   }
 
   initialiseCORS () {
-    this.server.use((req, res, next) => {
-      res.header('Access-Control-Allow-Origin', '*')
-      res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+    console.log('in initialiseCORS');
+    this.corsOptions = {
+      origin: [/http[s]?:\/\/localhost:?\d*/, /http[s]?:\/\/10.0.2.2:?\d*/], 
+      //origin: /example\.com$/, 
+      allowedHeaders: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept']
+    }
 
-      next()
-    })
+    // this.server.use((req, res, next) => {
+    //   res.header('Access-Control-Allow-Origin', '*')
+    //   res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept')
+
+    //   next()
+    // })
   }
 
   initialiseRoutes () {
@@ -48,6 +56,7 @@ class StaticmanAPI {
     this.server.get(
       '/v:version/connect/:username/:repository',
       this.bruteforce.prevent,
+      cors(this.corsOptions), 
       this.requireApiVersion([1, 2]),
       this.controllers.connect
     )
@@ -56,6 +65,7 @@ class StaticmanAPI {
     this.server.post(
       '/v:version/entry/:username/:repository/:branch',
       this.bruteforce.prevent,
+      cors(this.corsOptions), 
       this.requireApiVersion([1, 2]),
       this.requireParams(['fields']),
       this.controllers.process
@@ -64,6 +74,7 @@ class StaticmanAPI {
     this.server.post(
       '/v:version/entry/:username/:repository/:branch/:property',
       this.bruteforce.prevent,
+      cors(this.corsOptions), 
       this.requireApiVersion([2]),
       this.requireParams(['fields']),
       this.controllers.process
@@ -72,6 +83,7 @@ class StaticmanAPI {
     this.server.post(
       '/v:version/entry/:service/:username/:repository/:branch/:property',
       this.bruteforce.prevent,
+      cors(this.corsOptions), 
       this.requireApiVersion([3]),
       this.requireService(['github', 'gitlab']),
       this.requireParams(['fields']),
@@ -82,6 +94,7 @@ class StaticmanAPI {
     this.server.get(
       '/v:version/encrypt/:text',
       this.bruteforce.prevent,
+      cors(this.corsOptions), 
       this.requireApiVersion([2, 3]),
       this.controllers.encrypt
     )
@@ -90,6 +103,7 @@ class StaticmanAPI {
     this.server.get(
       '/v:version/auth/:service/:username/:repository/:branch/:property',
       this.bruteforce.prevent,
+      cors(this.corsOptions), 
       this.requireApiVersion([2, 3]),
       this.requireService(['github', 'gitlab']),
       this.controllers.auth


### PR DESCRIPTION
This addresses https://github.com/eduardoboucas/staticman/issues/401 - "Allow for customizing the size of generated comment IDs"

Two new config options have been added to the JSON-based config:
```
commentIdGenerator: {
  doc: 'The scheme to use for generating IDs for comments. More info about nanoid - https://github.com/ai/nanoid',
  format: ['uuid', 'nanoid', 'nanoid-lowercase'],
  default: 'uuid',
  env: 'COMMENT_ID_GENERATOR'
}
```

```
commentIdLength: {
  doc: 'The desired length of generated comment IDs. Only applicable when commentIdGenerator is set to "nanoid" or "nanoid-lowercase"',
  format: Number,
  default: 21,
  env: 'COMMENT_ID_LENGTH'
}
```

Currently, Staticman creates all comment IDs as UUIDs. While using UUIDs is a fool-proof solution that basically guarantees the uniqueness of IDs, it can be overkill. Consider a small blog that receives, at most, one comment each day/week/month/etc. For many/most users, the nature of the IDs that Staticman generates will not matter. However, the Staticman configuration allows for the generated ID to be exposed, when desired. For example, it can be incorporated into the filenames generated by Staticman.

For usage scenarios such as these, it is desirable to be able to configure Staticman to generate shorter/simpler comment IDs. [Nano ID](https://github.com/ai/nanoid) has been added to achieve this.

For example, if `commentIdGenerator` is set to `nanoid-lowercase` and `commentIdLength` is set to `8`, IDs akin to the following will be generated: `ry6-bt9d`

According the the [Nano ID Collision Calculator](https://zelark.github.io/nano-id-cc/), for a blog receiving one comment submission every hour, "~34 years [would be] needed, in order to have a 1% probability of at least one collision".