### PR TITLE
Allow for bypassing Akismet spam-checking (when testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Staticwoman is a fork of [Staticman](https://github.com/eduardoboucas/staticman)
 - [Customizing the subject and content of notification emails](https://github.com/hispanic/staticwoman/pull/4)
 - [Double opt-in for notification emails and GDPR compliance](https://github.com/hispanic/staticwoman/pull/6)
 - [Customizing the size of generated comment IDs](https://github.com/hispanic/staticwoman/pull/9)
+- [Allow for bypassing Akismet spam-checking when testing](https://github.com/hispanic/staticwoman/pull/10)
 
 I expect that the original Staticman project will include some version of the above functionality sooner or later. Until then, here 'tis. I haven't made any effort to document this new functionality beyond the comments found in the above-referenced pull requests. If you have interest in making use of any of these features and you'd like to see said documentation created, please open an issue and I'll see what I can do. 
 

--- a/config.js
+++ b/config.js
@@ -17,6 +17,12 @@ const schema = {
       format: String,
       default: null,
       env: 'AKISMET_API_KEY'
+    },
+    bypassValue: {
+      doc: 'Value to pass in as comment author, author email, author URL, or content in order to bypass Akismet spam-checking. Intended to be used for testing in lieu of disabling Akismet via the site config.',
+      format: String,
+      default: null,
+      env: 'AKISMET_BYPASS_VALUE'
     }
   },
   analytics: {

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -155,7 +155,7 @@ class Staticman {
         blog: config.get('akismet.site')
       })
 
-      akismet.checkSpam({
+      const akismetData = {
         user_ip: this.ip,
         user_agent: this.userAgent,
         comment_type: this.siteConfig.get('akismet.type'),
@@ -163,7 +163,18 @@ class Staticman {
         comment_author_email: fields[this.siteConfig.get('akismet.authorEmail')],
         comment_author_url: fields[this.siteConfig.get('akismet.authorUrl')],
         comment_content: fields[this.siteConfig.get('akismet.content')]
-      }, (err, isSpam) => {
+      }
+      const akismetBypassValue = config.get('akismet.bypassValue')
+      if (akismetBypassValue !== null && akismetBypassValue !== '' && typeof akismetBypassValue !== 'undefined') {
+        if (akismetData.comment_author === akismetBypassValue ||
+          akismetData.comment_author_email === akismetBypassValue ||
+          akismetData.comment_author_url === akismetBypassValue ||
+          akismetData.comment_content === akismetBypassValue) {
+          return Promise.resolve(fields)
+        }
+      }
+
+      akismet.checkSpam(akismetData, (err, isSpam) => {
         if (err) return reject(err)
 
         if (isSpam) return reject(errorHandler('IS_SPAM'))

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -170,7 +170,7 @@ class Staticman {
           akismetData.comment_author_email === akismetBypassValue ||
           akismetData.comment_author_url === akismetBypassValue ||
           akismetData.comment_content === akismetBypassValue) {
-          return Promise.resolve(fields)
+          return resolve(fields)
         }
       }
 


### PR DESCRIPTION
This addresses https://github.com/eduardoboucas/staticman/issues/404 - "Allow for bypassing Akismet spam-checking (when testing)"

One new config option has been added to the JSON-based config:
```
    bypassValue: {
      doc: 'Value to pass in as comment author, author email, author URL, or content in order to bypass Akismet spam-checking. Intended to be used for testing in lieu of disabling Akismet via the site config.',
      format: String,
      default: null,
      env: 'AKISMET_BYPASS_VALUE'
    }
```

In Staticman, currently, Akismet spam-checking is turned on/off via the `akismet.enabled` property in the site config. When running Staticman in a testing, staging, or production environment, it would help facilitate testing if there was a per-request way to bypass Akismet spam-checking. Pumping too many test comments through Akismet (the free plan that does not allow for any review) can result in Akismet flagging test data as spam.

With this change, if the author name, author email, author url, or comment content are set to the bypass value, Akismet will **not** be invoked for the submission. This allows Akismet to remain enabled, but bypass-able by in-the-know testers.