### PR TITLE
Allow for configuring the Mailgun region/host

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Staticwoman is a fork of [Staticman](https://github.com/eduardoboucas/staticman)
 - [Customizing the size of generated comment IDs](https://github.com/hispanic/staticwoman/pull/9)
 - [Bypassing Akismet spam-checking when testing](https://github.com/hispanic/staticwoman/pull/10)
 - [Support for a development lifecycle that progresses through multiple environments (e.g., dev, staging, prod)](https://github.com/hispanic/staticwoman/pull/11)
+- [Configuring the Mailgun region/host](https://github.com/hispanic/staticwoman/pull/12)
 
 I expect that the original Staticman project will include some version of the above functionality sooner or later. Until then, here 'tis. I haven't made any effort to document this new functionality beyond the comments found in the above-referenced pull requests. If you have interest in making use of any of these features and you'd like to see said documentation created, please open an issue and I'll see what I can do. 
 

--- a/config.js
+++ b/config.js
@@ -50,6 +50,12 @@ const schema = {
     env: 'BRANCH'
   },
   email: {
+    apiHost: {
+      doc: 'Mailgun API host/region to be used for email notifications. Will be overridden by a `notifications.apiHost` parameter in the site/repo config, if one is set.',
+      format: String,
+      default: 'api.mailgun.net',
+      env: 'EMAIL_API_HOST'
+    },
     apiKey: {
       doc: 'Mailgun API key to be used for email notifications. Will be overridden by a `notifications.apiKey` parameter in the site/repo config, if one is set.',
       format: String,

--- a/lib/Staticman.js
+++ b/lib/Staticman.js
@@ -390,6 +390,7 @@ class Staticman {
     // Initialise Mailgun
     const mailgun = Mailgun({
       apiKey: this.siteConfig.get('notifications.apiKey') || config.get('email.apiKey'),
+      host: this.siteConfig.get('notifications.apiHost') || config.get('email.apiHost'),
       domain: this.siteConfig.get('notifications.domain') || config.get('email.domain')
     })
 

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -157,6 +157,11 @@ const schema = {
       format: ['none', 'single', 'double'],
       default: 'none'
     },
+    apiHost: {
+      doc: 'Mailgun API host/region',
+      format: String,
+      default: ''
+    },
     apiKey: {
       doc: 'Mailgun API key',
       format: 'EncryptedString',

--- a/staticman.sample.yml
+++ b/staticman.sample.yml
@@ -57,6 +57,9 @@ comments:
     # Mailgun API key
     #apiKey: "1q2w3e4r"
 
+    # Mailgun API host/region. If in EU region, use 'api.eu.mailgun.net'.
+    #apiHost: "api.mailgun.net"
+
     # (!) ENCRYPTED
     #
     # Mailgun domain (encrypted)


### PR DESCRIPTION
This addresses https://github.com/eduardoboucas/staticman/issues/274 - "Add support for mailgun EU-region api"

The following property has been added to the schema for the JSON-formatted "server" configuration file:

```
    apiHost: {
      doc: 'Mailgun API host/region to be used for email notifications. Will be overridden by a `notifications.apiHost` parameter in the site/repo config, if one is set.',
      format: String,
      default: 'api.mailgun.net',
      env: 'EMAIL_API_HOST'
    },
```

A corollary property has been added to the YAML-formatted "site/repo" file. This allows for targeting either the US or EU Mailgun region.
